### PR TITLE
Add study user activity syncs to firehose

### DIFF
--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -15,6 +15,7 @@ COPY lib/log/logger.py ./lib/log/logger.py
 
 COPY transform/* ./transform/
 
+COPY services/participant_data/study_users.py ./services/participant_data/study_users.py
 COPY services/sync/stream/* ./services/sync/stream/
 COPY services/consolidate_post_records/* ./services/consolidate_post_records/
 

--- a/lib/aws/s3.py
+++ b/lib/aws/s3.py
@@ -67,6 +67,7 @@ class S3:
     ) -> None:
         """Writes list of dictionaries as JSONL to S3."""
         if not data:
+            print("No data to write to S3.")
             return
         if not key.endswith(".jsonl"):
             key = f"{key}.jsonl"
@@ -196,6 +197,9 @@ class S3:
                     with open(fp, "r") as f:
                         jsons.append(json.load(f))
                     filepaths.append(fp)
+            if len(jsons) == 0:
+                print(f"No JSON files found in directory: {directory}.")
+                print("Not writing anything to S3.")
             if not key:
                 key = os.path.join(S3_FIREHOSE_KEY_ROOT, filename)
             if compressed:

--- a/lib/db/bluesky_models/raw.py
+++ b/lib/db/bluesky_models/raw.py
@@ -106,7 +106,7 @@ class RawFollow(BaseModel):
     record: RawFollowRecord = Field(..., description="The actual follow record.")  # noqa
     author: str = Field(..., description="The DID of the author of the follow. Matches follower_did.")  # noqa
     follower_did: str = Field(..., description="The DID of the user doing the following.")  # noqa
-    follow_did: str = Field(..., description="The DID of the user being followed.")  # noqa
+    followee_did: str = Field(..., description="The DID of the user being followed.")  # noqa
 
 
 class FirehoseSubscriptionStateCursorModel(BaseModel):

--- a/pipelines/sync_post_records/firehose/firehose.py
+++ b/pipelines/sync_post_records/firehose/firehose.py
@@ -8,7 +8,7 @@ logger = Logger(__name__)
 def get_posts() -> None:
     logger.info("Getting posts from the firehose.")
     try:
-        start_app()
+        start_app(restart_cursor=True)
         logger.info("Successfully fetched posts from the firehose.")
     except Exception as e:
         logger.error(f"Error getting posts from the firehose: {e}")

--- a/services/participant_data/helper.py
+++ b/services/participant_data/helper.py
@@ -178,3 +178,15 @@ def get_all_users() -> list[UserToBlueskyProfileModel]:
     except ClientError as e:
         print(f"Failed to fetch users from DynamoDB: {e}")
         return []
+
+
+# TODO: verify that this happens only once, on script load.
+current_study_users: list[UserToBlueskyProfileModel] = get_all_users()
+set_current_study_user_dids = set([
+    user.bluesky_user_did for user in current_study_users
+])
+
+
+def check_if_user_in_study(user_did: str) -> bool:
+    """Checks if a user is in the study."""
+    return user_did in set_current_study_user_dids

--- a/services/participant_data/helper.py
+++ b/services/participant_data/helper.py
@@ -178,15 +178,3 @@ def get_all_users() -> list[UserToBlueskyProfileModel]:
     except ClientError as e:
         print(f"Failed to fetch users from DynamoDB: {e}")
         return []
-
-
-# TODO: verify that this happens only once, on script load.
-current_study_users: list[UserToBlueskyProfileModel] = get_all_users()
-set_current_study_user_dids = set([
-    user.bluesky_user_did for user in current_study_users
-])
-
-
-def check_if_user_in_study(user_did: str) -> bool:
-    """Checks if a user is in the study."""
-    return user_did in set_current_study_user_dids

--- a/services/participant_data/study_users.py
+++ b/services/participant_data/study_users.py
@@ -1,0 +1,91 @@
+"""Tracks the users in the study, for checking against the streamed data.
+
+Performs the following tasks:
+- Checks to see if user activity (posts/likes/follows) is from a study user.
+- Checks to see if a repost is of a post from a study user.
+- Checks to see if a like is of a post from a study user.
+"""
+import json
+import os
+import threading
+
+import boto3
+from services.participant_data.helper import get_all_users
+
+
+class StudyUserManager:
+    """Singleton class for managing study users and their posts.
+
+    We use this class for tracking the users in the study, for checking against
+    the streamed data.
+    """
+    _instance = None
+    _lock = threading.Lock()
+
+    _instance = None
+
+    @staticmethod
+    def get_instance():
+        if StudyUserManager._instance is None:
+            StudyUserManager._instance = StudyUserManager()
+        return StudyUserManager._instance
+
+    def __init__(self):
+        if StudyUserManager._instance is not None:
+            raise Exception("StudyUserManager class is intended to be a singleton instance.")  # noqa
+        self.s3 = boto3.client("s3")
+        self.s3_bucket = "bluesky-research"
+        self.study_users_dids_set: set = self._load_study_user_dids_from_s3()
+        self.post_uri_to_study_user_did_map: dict = (
+            self._load_post_uri_to_study_user_did_map_from_s3()
+        )
+        self.file_to_key_map = {
+            "study_user_dids": os.path.join(
+                "participant_data", "study_user_dids.json"
+            ),
+            "post_uri_to_study_user_did": os.path.join(
+                "participant_data", "post_uri_to_study_user_did.json"
+            )
+        }
+
+    def _load_study_user_dids(self):
+        """Load the study_users_dids_set from DynamoDB."""
+        study_users = get_all_users()
+        self.study_users_dids_set = set(
+            [user.bluesky_user_did for user in study_users]
+        )
+
+    def _load_post_uri_to_study_user_did_map_from_s3(self):
+        """Load the post_uri_to_study_user_did_map from S3."""
+        key = self.file_to_key_map["post_uri_to_study_user_did"]
+        try:
+            response = self.s3.get_object(Bucket=self.bucket, Key=key)
+            post_uri_to_study_user_did_map = json.loads(response["Body"].read())
+        except self.s3.exceptions.NoSuchKey:
+            post_uri_to_study_user_did_map = {}
+        self.post_uri_to_study_user_did_map = post_uri_to_study_user_did_map
+
+    def _write_post_uri_to_study_user_did_map_to_s3(self):
+        """Write the post_uri_to_study_user_did_map to S3."""
+        key = self.file_to_key_map["post_uri_to_study_user_did"]
+        self.s3.put_object(
+            Bucket=self.s3_bucket,
+            Key=key,
+            Body=json.dumps(self.post_uri_to_study_user_did_map)
+        )
+
+    def is_study_user(self, user_did: str) -> bool:
+        """Check if a user is in the study."""
+        return user_did in self.study_users_dids_set
+
+    def is_study_user_post(self, post_uri: str) -> bool:
+        """Check if a post is from a study user."""
+        return post_uri in self.post_uri_to_study_user_did_map
+
+    def insert_study_user_post(self, post_uri: str, user_did: str):
+        """Insert a post from a study user."""
+        self.post_uri_to_study_user_did_map[post_uri] = user_did
+        self._write_post_uri_to_study_user_did_map_to_s3()
+
+
+study_user_manager = StudyUserManager.get_instance()

--- a/services/participant_data/study_users.py
+++ b/services/participant_data/study_users.py
@@ -57,16 +57,28 @@ class StudyUserManager:
             self.study_users_dids_set = set()
             self.post_uri_to_study_user_did_map = {}
 
-    def _load_study_user_dids(self):
+    def _load_study_user_dids(self) -> set[str]:
         """Load the study_users_dids_set from DynamoDB."""
+        print(
+            """
+            THIS SHOULD ONLY BE CALLED AT THE BEGINNING OF THE STREAMING
+            PROCESS
+            """
+        )
+        print(
+            """
+            Since this is a singleton class, the study users should only
+            be loaded once at the beginning of the streaming process.
+            """
+        )
         study_users = get_all_users()
-        self.study_users_dids_set = set(
+        return set(
             [user.bluesky_user_did for user in study_users]
         )
 
     def _load_post_uri_to_study_user_did_map_from_s3(
         self, use_new_hashmap: bool = False
-    ):
+    ) -> dict:
         """Load the post_uri_to_study_user_did_map from S3."""
         key = self.file_to_key_map["post_uri_to_study_user_did"]
         try:
@@ -74,7 +86,7 @@ class StudyUserManager:
             post_uri_to_study_user_did_map = json.loads(response["Body"].read())
         except self.s3.exceptions.NoSuchKey or use_new_hashmap:
             post_uri_to_study_user_did_map = {}
-        self.post_uri_to_study_user_did_map = post_uri_to_study_user_did_map
+        return post_uri_to_study_user_did_map
 
     def _load_aws_data(self):
         """Load the study user data from AWS."""

--- a/services/participant_data/study_users.py
+++ b/services/participant_data/study_users.py
@@ -91,7 +91,9 @@ class StudyUserManager:
     def _load_aws_data(self):
         """Load the study user data from AWS."""
         self.study_users_dids_set = self._load_study_user_dids()
-        self.post_uri_to_study_user_did_map = self._load_post_uri_to_study_user_did_map_from_s3()
+        self.post_uri_to_study_user_did_map = (
+            self._load_post_uri_to_study_user_did_map_from_s3()
+        )
 
     def _write_post_uri_to_study_user_did_map_to_s3(self):
         """Write the post_uri_to_study_user_did_map to S3."""

--- a/services/sync/stream/app.py
+++ b/services/sync/stream/app.py
@@ -1,7 +1,10 @@
+"""Flask app for connecting to the firehose data stream and running  pipeline."""
+
 import sys
 import signal
 import threading
 import time
+from typing import Optional
 
 from flask import Flask
 
@@ -10,14 +13,22 @@ from services.sync.stream.data_filter import operations_callback
 
 
 app = Flask(__name__)
-firehose_name = "firehose_stream"
+default_firehose_name = "firehose_stream"
 
 
-def start_app():
+def start_app(
+    firehose_name: Optional[str] = default_firehose_name,
+    restart_cursor: bool = False
+):
     start_time = time.time()
     stream_stop_event = threading.Event()
-    stream_args = (firehose_name, operations_callback, stream_stop_event)
-    stream_thread = threading.Thread(target=firehose.run, args=stream_args)
+    stream_kwargs = {
+        "name": firehose_name,
+        "operations_callback": operations_callback,
+        "stream_stop_event": stream_stop_event,
+        "restart_cursor": restart_cursor
+    }
+    stream_thread = threading.Thread(target=firehose.run, kwargs=stream_kwargs)
     print('Starting data stream...')
     # something like 3:49pm UTC
     start_time_str = time.strftime(

--- a/services/sync/stream/data_filter.py
+++ b/services/sync/stream/data_filter.py
@@ -17,8 +17,11 @@ from services.sync.stream.export_data import (
 )
 from services.consolidate_post_records.helper import consolidate_firehose_post
 from services.consolidate_post_records.models import ConsolidatedPostRecordModel  # noqa
-from services.participant_data.study_users import study_user_manager
+from services.participant_data.study_users import get_study_user_manager
 from transform.transform_raw_data import process_firehose_post
+
+
+study_user_manager = get_study_user_manager()
 
 
 def manage_like(like: dict, operation: Literal["create", "delete"]) -> None:

--- a/services/sync/stream/data_filter.py
+++ b/services/sync/stream/data_filter.py
@@ -52,7 +52,6 @@ def manage_like(like: dict, operation: Literal["create", "delete"]) -> None:
         uri_suffix = like["uri"].split('/')[-1]
         filename = f"like_uri_suffix={uri_suffix}.json"
         like_model_dict = like
-        like_model_dict["record"] = like["record"].dict()
 
     folder_path = export_filepath_map[operation]["like"]
     full_path = os.path.join(folder_path, filename)
@@ -158,7 +157,6 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
         follow_uri_suffix = follow["uri"].split('/')[-1]
         filename = f"follow_uri_suffix={follow_uri_suffix}.json"
         follow_model_dict = follow
-        follow_model_dict["record"] = follow["record"].dict()
 
     folder_path = export_filepath_map[operation]["follow"]
     full_path = os.path.join(folder_path, filename)
@@ -259,7 +257,6 @@ def manage_post(post: dict, operation: Literal["create", "delete"]):
         post_uri_suffix = post["uri"].split('/')[-1]
         filename = f"post_uri_suffix={post_uri_suffix}.json"
         consolidated_post_dict = post
-        consolidated_post_dict["record"] = post["record"].dict()
 
     folder_path = export_filepath_map[operation]["post"]
     full_path = os.path.join(folder_path, filename)

--- a/services/sync/stream/data_filter.py
+++ b/services/sync/stream/data_filter.py
@@ -48,17 +48,7 @@ def manage_like(like: dict, operation: Literal["create", "delete"]) -> None:
         # manage tracking the posts liked later, as long as we know who
         # created the like.
         filename = f"like_author_did={like_author_did}_like_uri_suffix={uri_suffix}.json"
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        # Case 1: the user is the one who likes a post.
-        is_study_user = study_user_manager.is_study_user(user_did=like_author_did)
-        if not is_study_user:
-            return
-        breakpoint()
-        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        return
-        ### END OF TEMPORARY CODE CHUNK ###
         uri_suffix = like["uri"].split('/')[-1]
         filename = f"like_uri_suffix={uri_suffix}.json"
         like_model_dict = like
@@ -163,17 +153,7 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
         follower_did = follow_model.follower_did
         followee_did = follow_model.followee_did
         filename = f"follower_did={follower_did}_followee_did={followee_did}.json"
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        user_is_follower = study_user_manager.is_study_user(user_did=follower_did)  # noqa
-        user_is_followee = study_user_manager.is_study_user(user_did=followee_did)  # noqa
-        if not (user_is_follower or user_is_followee):
-            return
-        breakpoint()
-        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        return
-        ### END OF TEMPORARY CODE CHUNK ###
         follow_uri_suffix = follow["uri"].split('/')[-1]
         filename = f"follow_uri_suffix={follow_uri_suffix}.json"
         follow_model_dict = follow
@@ -271,16 +251,7 @@ def manage_post(post: dict, operation: Literal["create", "delete"]):
         # URI takes the form at://<author DID>/<collection>/<post URI>
         post_uri_suffix = consolidated_post_dict["uri"].split('/')[-1]  # e.g., 3kwd3wuubke2i # noqa
         filename = f"author_did={author_did}_post_uri_suffix={post_uri_suffix}.json"  # noqa
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        is_study_user = study_user_manager.is_study_user(user_did=author_did)
-        if not is_study_user:
-            return
-        breakpoint()
-        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
-        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
-        return
-        ### END OF TEMPORARY CODE CHUNK ###
         post_uri_suffix = post["uri"].split('/')[-1]
         filename = f"post_uri_suffix={post_uri_suffix}.json"
         consolidated_post_dict = post

--- a/services/sync/stream/data_filter.py
+++ b/services/sync/stream/data_filter.py
@@ -48,7 +48,17 @@ def manage_like(like: dict, operation: Literal["create", "delete"]) -> None:
         # manage tracking the posts liked later, as long as we know who
         # created the like.
         filename = f"like_author_did={like_author_did}_like_uri_suffix={uri_suffix}.json"
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        # Case 1: the user is the one who likes a post.
+        is_study_user = study_user_manager.is_study_user(user_did=like_author_did)
+        if not is_study_user:
+            return
+        breakpoint()
+        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        return
+        ### END OF TEMPORARY CODE CHUNK ###
         uri_suffix = like["uri"].split('/')[-1]
         filename = f"like_uri_suffix={uri_suffix}.json"
         like_model_dict = like
@@ -153,7 +163,17 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
         follower_did = follow_model.follower_did
         followee_did = follow_model.followee_did
         filename = f"follower_did={follower_did}_followee_did={followee_did}.json"
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        user_is_follower = study_user_manager.is_study_user(user_did=follower_did)  # noqa
+        user_is_followee = study_user_manager.is_study_user(user_did=followee_did)  # noqa
+        if not (user_is_follower or user_is_followee):
+            return
+        breakpoint()
+        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        return
+        ### END OF TEMPORARY CODE CHUNK ###
         follow_uri_suffix = follow["uri"].split('/')[-1]
         filename = f"follow_uri_suffix={follow_uri_suffix}.json"
         follow_model_dict = follow
@@ -170,10 +190,8 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
         user_is_follower = study_user_manager.is_study_user(user_did=follower_did)  # noqa
         user_is_followee = study_user_manager.is_study_user(user_did=followee_did)  # noqa
         if user_is_follower or user_is_followee:
-            # edge case: user can't be both follower and followee. User can't follow themselves.
-            if user_is_follower and user_is_followee:
-                raise ValueError("User can't be both follower and followee.")
-
+            # someone can follow someone else in the study, in which case both
+            # the follower and followee need to be registered.
             if user_is_follower:
                 print(f"User {follower_did} followed a new account, {followee_did}.")  # noqa
                 export_study_user_data_local(
@@ -184,7 +202,7 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
                     filename=filename,
                     kwargs={"follow_status": "follower"}
                 )
-            elif user_is_followee:
+            if user_is_followee:
                 print(f"User {followee_did} was followed by a new account, {follower_did}.")  # noqa
                 export_study_user_data_local(
                     record=follow_model_dict,
@@ -253,7 +271,16 @@ def manage_post(post: dict, operation: Literal["create", "delete"]):
         # URI takes the form at://<author DID>/<collection>/<post URI>
         post_uri_suffix = consolidated_post_dict["uri"].split('/')[-1]  # e.g., 3kwd3wuubke2i # noqa
         filename = f"author_did={author_did}_post_uri_suffix={post_uri_suffix}.json"  # noqa
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        is_study_user = study_user_manager.is_study_user(user_did=author_did)
+        if not is_study_user:
+            return
+        breakpoint()
+        ### END OF TEMPORARY CODE CHUNK ###
     elif operation == "delete":
+        ### TEMPORARY CODE CHUNK, JUST FOR TESTING ###
+        return
+        ### END OF TEMPORARY CODE CHUNK ###
         post_uri_suffix = post["uri"].split('/')[-1]
         filename = f"post_uri_suffix={post_uri_suffix}.json"
         consolidated_post_dict = post

--- a/services/sync/stream/export_data.py
+++ b/services/sync/stream/export_data.py
@@ -51,6 +51,7 @@ from lib.constants import root_local_data_directory
 from lib.db.bluesky_models.raw import FirehoseSubscriptionStateCursorModel
 from lib.db.manage_local_data import write_jsons_to_local_store
 from lib.helper import generate_current_datetime_str
+from services.participant_data.study_users import get_study_user_manager
 
 current_file_directory = os.path.dirname(os.path.abspath(__file__))
 root_write_path = os.path.join(current_file_directory, "cache")
@@ -113,6 +114,8 @@ s3 = S3()
 dynamodb = DynamoDB()
 
 SUBSCRIPTION_STATE_TABLE_NAME = "firehoseSubscriptionState"
+
+study_user_manager = get_study_user_manager()
 
 
 def rebuild_cache_paths():
@@ -495,7 +498,15 @@ def export_study_user_post(
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
     full_path = os.path.join(folder_path, filename)
+
+    # export JSON file.
     write_data_to_json(data=record, path=full_path)
+
+    # update StudyUserManager store with new post.
+    study_user_manager.insert_study_user_post(
+        post_uri=record["uri"],
+        user_did=author_did
+    )
 
 
 def export_study_user_follow(
@@ -679,7 +690,3 @@ def export_study_user_data_local(
             filename=filename,
             user_post_type=kwargs.get("user_post_type")
         )
-
-
-def export_study_user_data_s3():
-    pass

--- a/services/sync/stream/firehose.py
+++ b/services/sync/stream/firehose.py
@@ -143,7 +143,7 @@ def _run(name, operations_callback, stream_stop_event=None):  # noqa: C901
             if counter_value % cursor_update_frequency == 0:
                 print(f"Counter: {counter_value}")
                 print("Writing cached records to S3 and resetting cache...")
-                export_batch(external_store=["local", "s3"])
+                export_batch(external_store=["s3"])
                 print(f"Updating cursor state with cursor={counter_value}...")  # noqa
                 cursor_state = {
                     "service": name,

--- a/services/sync/stream/firehose.py
+++ b/services/sync/stream/firehose.py
@@ -90,20 +90,38 @@ def _get_ops_by_type(commit: models.ComAtprotoSyncSubscribeRepos.Commit) -> dict
     return operation_by_type
 
 
-def run(name, operations_callback, stream_stop_event=None):
+def run(
+    name,
+    operations_callback,
+    stream_stop_event=None,
+    restart_cursor: bool = False
+):
     while stream_stop_event is None or not stream_stop_event.is_set():
         try:
-            _run(name, operations_callback, stream_stop_event)
+            _run(
+                name=name,
+                operations_callback=operations_callback,
+                stream_stop_event=stream_stop_event,
+                restart_cursor=restart_cursor
+            )
         except FirehoseError as e:
             # here we can handle different errors to reconnect to firehose
             raise e
 
 
-def _run(name, operations_callback, stream_stop_event=None):  # noqa: C901
+def _run(
+    name,
+    operations_callback,
+    stream_stop_event=None,
+    restart_cursor: bool = False
+):
     """Run firehose stream."""
-    state: Optional[FirehoseSubscriptionStateCursorModel] = (
-        load_cursor_state_s3(service_name=name)
-    )
+    if not restart_cursor:
+        state: Optional[FirehoseSubscriptionStateCursorModel] = (
+            load_cursor_state_s3(service_name=name)
+        )
+    else:
+        state = None
 
     if state:
         params = models.ComAtprotoSyncSubscribeRepos.Params(cursor=state.cursor)  # noqa

--- a/services/sync/stream/tests/conftest.py
+++ b/services/sync/stream/tests/conftest.py
@@ -1,0 +1,117 @@
+"""Helper utilities for pytest functions."""
+import copy
+import os
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+
+from services.sync.stream.tests.mock_firehose_data import (
+    mock_user_dids, mock_post_uri_to_user_did_map, mock_follow_records,
+    mock_like_records, mock_post_records
+)
+
+
+def clean_path(path: str):
+    if os.path.exists(path):
+        os.remove(path)
+
+
+class MockStudyUserManager:
+    """Mock class for the StudyUserManager singleton."""
+
+    def __init__(self):
+        self.study_users_dids_set = mock_user_dids
+        self.post_uri_to_study_user_did_map = mock_post_uri_to_user_did_map
+
+    def is_study_user(self, user_did: str) -> bool:
+        """Mock function for checking if a user is a study user."""
+        return user_did in self.study_users_dids_set
+
+    def is_study_user_post(self, post_uri: str) -> Optional[str]:
+        """Mock function for checking if a post is from a study user."""
+        return self.post_uri_to_study_user_did_map.get(post_uri, None)
+
+
+class MockS3():
+    """Mock patch class of the `S3` utility class."""
+
+    def __init__(self):
+        super().__init__()
+        self.write_dict_json_to_s3 = Mock()
+
+
+mock_s3 = MockS3()
+
+
+mock_study_manager = MockStudyUserManager()
+
+
+def get_mock_study_manager():
+    return mock_study_manager
+
+
+@pytest.fixture(autouse=True)
+def mock_study_user_manager(monkeypatch):
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.study_user_manager.is_study_user",
+        mock_study_manager.is_study_user
+    )
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.study_user_manager.is_study_user_post",  # noqa
+        mock_study_manager.is_study_user_post
+    )
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.get_study_user_manager",
+        get_mock_study_manager
+    )
+    monkeypatch.setattr(
+        "services.participant_data.study_users.get_study_user_manager",
+        get_mock_study_manager
+    )
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.study_user_manager",
+        mock_study_manager
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_s3_fixture(monkeypatch):
+    monkeypatch.setattr("services.sync.stream.export_data.s3", mock_s3)
+    monkeypatch.setattr(
+        "services.sync.stream.export_data.s3.write_dict_json_to_s3",
+        mock_s3.write_dict_json_to_s3
+    )
+
+
+@pytest.fixture
+def cleanup_files(request):
+    files_to_cleanup = []
+
+    def add_file(filepath):
+        files_to_cleanup.append(filepath)
+
+    def cleanup():
+        for filepath in files_to_cleanup:
+            clean_path(filepath)
+            print(f"Deleted {filepath}")
+
+    request.addfinalizer(cleanup)
+    return add_file
+
+
+# create fixtures for each mock records list, to avoid different tests
+# collidiing with each other.
+@pytest.fixture
+def mock_follow_records_fixture():
+    return copy.deepcopy(mock_follow_records)
+
+
+@pytest.fixture
+def mock_like_records_fixture():
+    return copy.deepcopy(mock_like_records)
+
+
+@pytest.fixture
+def mock_post_records_fixture():
+    return copy.deepcopy(mock_post_records)

--- a/services/sync/stream/tests/conftest.py
+++ b/services/sync/stream/tests/conftest.py
@@ -39,6 +39,10 @@ class MockS3():
     def __init__(self):
         super().__init__()
         self.write_dict_json_to_s3 = Mock()
+        self.write_local_jsons_to_s3 = Mock()
+        self.create_partition_key_based_on_timestamp = Mock(
+            return_value="year=2024/month=08/day=01/hour=20/minute=39"
+        )
 
 
 mock_s3 = MockS3()
@@ -78,9 +82,30 @@ def mock_study_user_manager(monkeypatch):
 @pytest.fixture(autouse=True)
 def mock_s3_fixture(monkeypatch):
     monkeypatch.setattr("services.sync.stream.export_data.s3", mock_s3)
+    # patch study user activity writes
     monkeypatch.setattr(
         "services.sync.stream.export_data.s3.write_dict_json_to_s3",
         mock_s3.write_dict_json_to_s3
+    )
+    # patch general firehose writes
+    monkeypatch.setattr(
+        "services.sync.stream.export_data.s3.write_local_jsons_to_s3",
+        mock_s3.write_local_jsons_to_s3
+    )
+    # patch partition key on export.
+    # monkeypatch.setattr(
+    #     "services.sync.stream.export_data.s3.create_partition_key_based_on_timestamp", # noqa
+    #     "year=2024/month=08/day=01/hour=20/minute=39"
+    # )
+    monkeypatch.setattr(
+        "lib.aws.s3.S3.create_partition_key_based_on_timestamp",  # noqa
+        mock_s3.create_partition_key_based_on_timestamp
+    )
+    # patch the `generate_current_datetime_str` since this'll determine the
+    # compressed file's name.
+    monkeypatch.setattr(
+        "services.sync.stream.export_data.generate_current_datetime_str",
+        lambda: "2024-08-01-20:39:38"
     )
 
 

--- a/services/sync/stream/tests/mock_firehose_data.py
+++ b/services/sync/stream/tests/mock_firehose_data.py
@@ -1,0 +1,188 @@
+"""Mock firehose data, useful for unit testing."""
+from atproto_client.models.app.bsky.graph.follow import Record as FollowRecord
+from atproto_client.models.app.bsky.feed.like import Record as LikeRecord
+from atproto_client.models.app.bsky.feed.post import Main as Record, ReplyRef
+from atproto_client.models.com.atproto.repo.strong_ref import Main as StrongRef
+
+
+mock_user_dids = set([
+    "did:plc:study-user-1",
+    "did:plc:study-user-2",
+    "did:plc:study-user-3",
+])
+mock_post_uri_to_user_did_map = {
+    "at://did:plc:did-1/app.bsky.feed.post/post-uri-1": "did:plc:study-user-1",
+    "at://did:plc:did-2/app.bsky.feed.post/post-uri-2": "did:plc:study-user-2",
+    "at://did:plc:did-3/app.bsky.feed.post/post-uri-3": "did:plc:study-user-3",
+}
+
+mock_follow_records = [
+    {
+        'record': FollowRecord(
+            created_at='2024-07-02T17:48:48.627Z',
+            subject='did:plc:generic-user-1',
+            py_type='app.bsky.graph.follow'
+        ),
+        'uri': 'at://did:plc:follow-record/app.bsky.graph.follow/random-hash',
+        'cid': 'bafyreibwn4kwlezxabt2bzpopwfh7lbo56n4xb62wlbm5moqliwl4pzum4',
+        'author': 'did:plc:generic-user-2'
+    },  # generic follow record
+    {
+        'record': FollowRecord(
+            created_at='2024-07-02T17:48:48.627Z',
+            subject='did:plc:study-user-1',
+            py_type='app.bsky.graph.follow'
+        ),
+        'uri': 'at://did:plc:follow-record/app.bsky.graph.follow/random-hash',
+        'cid': 'bafyreibwn4kwlezxabt2bzpopwfh7lbo56n4xb62wlbm5moqliwl4pzum4',
+        'author': 'did:plc:generic-user-1'
+    },  # someone follows a study user (user is a followee)
+    {
+        'record': FollowRecord(
+            created_at='2024-07-02T17:48:48.627Z',
+            subject='did:plc:generic-user-1',
+            py_type='app.bsky.graph.follow'
+        ),
+        'uri': 'at://did:plc:follow-record/app.bsky.graph.follow/random-hash',
+        'cid': 'bafyreibwn4kwlezxabt2bzpopwfh7lbo56n4xb62wlbm5moqliwl4pzum4',
+        'author': 'did:plc:study-user-1'
+    },  # study user follows someone (user is a follower)
+]
+
+mock_like_records = [
+    {
+        'author': 'did:plc:generic-user-1',
+        'cid': 'bafyreihus4wvodsdmhsschvb57dn7qsl6wxanu5fv6httkq2njd7zqadri',
+        'record': LikeRecord(
+            created_at='2024-07-02T14:05:23.807Z',
+            subject=StrongRef(
+                cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                uri='at://did:plc:ucfj5xnywoxbdaxqelvpzyqz/app.bsky.feed.post/3kvkbi7yfb22z',
+                py_type='com.atproto.repo.strongRef'
+            ),
+            py_type='app.bsky.feed.like'
+        ),
+        'uri': 'at://did:plc:like-record-1/app.bsky.feed.like/like-record-suffix-123'  # noqa
+    },  # generic like record
+    {
+        'author': 'did:plc:study-user-1',
+        'cid': 'bafyreihus4wvodsdmhsschvb57dn7qsl6wxanu5fv6httkq2njd7zqadri',
+        'record': LikeRecord(
+            created_at='2024-07-02T14:05:23.807Z',
+            subject=StrongRef(
+                cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                uri="at://did:plc:did-1/app.bsky.feed.post/generic-post-uri-1",
+                py_type='com.atproto.repo.strongRef'
+            ),
+            py_type='app.bsky.feed.like'
+        ),
+        'uri': 'at://did:plc:like-record-2/app.bsky.feed.like/like-record-suffix-456'  # noqa
+    },  # a study user likes a post
+    {
+        'author': 'did:plc:generic-user-1',
+        'cid': 'bafyreihus4wvodsdmhsschvb57dn7qsl6wxanu5fv6httkq2njd7zqadri',
+        'record': LikeRecord(
+            created_at='2024-07-02T14:05:23.807Z',
+            subject=StrongRef(
+                cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                uri="at://did:plc:did-2/app.bsky.feed.post/post-uri-2",
+                py_type='com.atproto.repo.strongRef'
+            ),
+            py_type='app.bsky.feed.like'
+        ),
+        'uri': 'at://did:plc:aq45jcquopr4joswmfdpsfnh/app.bsky.feed.like/like-record-suffix-789'
+    }  # a study user's post is liked.
+]
+
+mock_post_records = [
+    {
+        'record': Record(
+            created_at='2024-02-07T05:10:02.159Z',
+            text='<Test post>',
+            embed=None,
+            entities=None,
+            facets=None,
+            labels=None,
+            langs=['en'],
+            reply=None,
+            tags=None,
+            py_type='app.bsky.feed.post'
+        ),
+        'uri': 'at://did:plc:sjeosezgc7mpqn6sfc7neabg/app.bsky.feed.post/post-uri-1',
+        'cid': 'bafyreidmb5wsupl6iz5wo2xjgusjpsrduug6qkpytjjckupdttot6jrbna',
+        'author': 'did:plc:generic-user-1'
+    },  # generic post record
+    {
+        'record': Record(
+            created_at='2024-02-07T05:10:02.159Z',
+            text='<Test post>',
+            embed=None,
+            entities=None,
+            facets=None,
+            labels=None,
+            langs=['en'],
+            reply=None,
+            tags=None,
+            py_type='app.bsky.feed.post'
+        ),
+        "uri": "at://did:plc:did-1/app.bsky.feed.post/post-uri-1",
+        'cid': 'bafyreidmb5wsupl6iz5wo2xjgusjpsrduug6qkpytjjckupdttot6jrbna',
+        'author': "did:plc:study-user-1"
+    },  # a post from a study user
+    {
+        'record': Record(
+            created_at='2024-02-07T05:10:02.159Z',
+            text='<Test post>',
+            embed=None,
+            entities=None,
+            facets=None,
+            labels=None,
+            langs=['en'],
+            reply=ReplyRef(
+                parent=StrongRef(
+                    cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                    uri="at://did:plc:did-1/app.bsky.feed.post/post-uri-1",  # by author="did:plc:study-user-1"
+                    py_type='com.atproto.repo.strongRef'
+                ),
+                root=StrongRef(
+                    cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                    uri="at://did:plc:random-did/app.bsky.feed.post/some-random-post-uri",
+                    py_type='com.atproto.repo.strongRef'
+                )
+            ),
+            tags=None,
+            py_type='app.bsky.feed.post'
+        ),
+        'uri': 'at://did:plc:sjeosezgc7mpqn6sfc7neabg/app.bsky.feed.post/generic-post-uri-1',
+        'cid': 'bafyreidmb5wsupl6iz5wo2xjgusjpsrduug6qkpytjjckupdttot6jrbna',
+        'author': 'did:plc:generic-user-1'
+    },  # a post in the same thread as a study user post (reply_parent) - replying to the user post # noqa
+    {
+        'record': Record(
+            created_at='2024-02-07T05:10:02.159Z',
+            text='<Test post>',
+            embed=None,
+            entities=None,
+            facets=None,
+            labels=None,
+            langs=['en'],
+            reply=ReplyRef(
+                parent=StrongRef(
+                    cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                    uri="at://did:plc:random-did/app.bsky.feed.post/some-random-post-uri",
+                    py_type='com.atproto.repo.strongRef'
+                ),
+                root=StrongRef(
+                    cid='bafyreif2ijylrc3cativstjcrbbcvtaa3xtptx23kkiqimq5y6hk2amdiy',
+                    uri="at://did:plc:did-1/app.bsky.feed.post/post-uri-1",  # by author="did:plc:study-user-1"
+                    py_type='com.atproto.repo.strongRef'
+                )
+            ),
+            tags=None,
+            py_type='app.bsky.feed.post'
+        ),
+        'uri': 'at://did:plc:sjeosezgc7mpqn6sfc7neabg/app.bsky.feed.post/generic-post-uri-1',
+        'cid': 'bafyreidmb5wsupl6iz5wo2xjgusjpsrduug6qkpytjjckupdttot6jrbna',
+        'author': 'did:plc:generic-user-1'
+    },  # a post in the same thread as a study user post (reply_root) - replying to the user post # noqa
+]

--- a/services/sync/stream/tests/mock_firehose_data.py
+++ b/services/sync/stream/tests/mock_firehose_data.py
@@ -28,6 +28,9 @@ mock_follow_records = [
         'author': 'did:plc:generic-user-2'
     },  # generic follow record
     {
+        'uri': 'at://did:plc:follow-record/app.bsky.graph.follow/random-hash'
+    },  # generic deleted record
+    {
         'record': FollowRecord(
             created_at='2024-07-02T17:48:48.627Z',
             subject='did:plc:study-user-1',
@@ -64,6 +67,9 @@ mock_like_records = [
         ),
         'uri': 'at://did:plc:like-record-1/app.bsky.feed.like/like-record-suffix-123'  # noqa
     },  # generic like record
+    {
+        'uri': 'at://did:plc:like-record-1/app.bsky.feed.like/like-record-suffix-123'
+    },  # generic deleted like record
     {
         'author': 'did:plc:study-user-1',
         'cid': 'bafyreihus4wvodsdmhsschvb57dn7qsl6wxanu5fv6httkq2njd7zqadri',
@@ -112,6 +118,9 @@ mock_post_records = [
         'cid': 'bafyreidmb5wsupl6iz5wo2xjgusjpsrduug6qkpytjjckupdttot6jrbna',
         'author': 'did:plc:generic-user-1'
     },  # generic post record
+    {
+        'uri': 'at://did:plc:sjeosezgc7mpqn6sfc7neabg/app.bsky.feed.post/post-uri-1'
+    },  # generic deleted post record
     {
         'record': Record(
             created_at='2024-02-07T05:10:02.159Z',

--- a/services/sync/stream/tests/test_data_filter.py
+++ b/services/sync/stream/tests/test_data_filter.py
@@ -1,0 +1,652 @@
+"""Tests for data_filter.py."""
+import copy
+import os
+from typing import Optional
+
+import pytest
+
+from services.sync.stream.data_filter import (
+    manage_follow, manage_follows, manage_like, manage_likes, manage_post,
+    manage_posts
+)
+from services.sync.stream.export_data import (
+    export_filepath_map, study_user_activity_relative_path_map,
+    study_user_activity_root_local_path
+)
+from services.sync.stream.tests.mock_firehose_data import (
+    mock_user_dids, mock_post_uri_to_user_did_map, mock_follow_records,
+    mock_like_records, mock_post_records
+)
+
+
+class MockStudyUserManager:
+    """Mock class for the StudyUserManager singleton."""
+
+    def __init__(self):
+        self.study_users_dids_set = mock_user_dids
+        self.post_uri_to_study_user_did_map = mock_post_uri_to_user_did_map
+
+    def is_study_user(self, user_did: str) -> bool:
+        """Mock function for checking if a user is a study user."""
+        return user_did in self.study_users_dids_set
+
+    def is_study_user_post(self, post_uri: str) -> Optional[str]:
+        """Mock function for checking if a post is from a study user."""
+        return self.post_uri_to_study_user_did_map.get(post_uri, None)
+
+
+mock_study_manager = MockStudyUserManager()
+
+
+def clean_path(path: str):
+    if os.path.exists(path):
+        os.remove(path)
+
+
+@pytest.fixture
+def mock_study_user_manager(monkeypatch):
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.study_user_manager.is_study_user",
+        mock_study_manager.is_study_user
+    )
+    monkeypatch.setattr(
+        "services.sync.stream.data_filter.study_user_manager.is_study_user_post",
+        mock_study_manager.is_study_user_post
+    )
+
+
+@pytest.fixture
+def cleanup_files(request):
+    files_to_cleanup = []
+
+    def add_file(filepath):
+        files_to_cleanup.append(filepath)
+
+    def cleanup():
+        for filepath in files_to_cleanup:
+            clean_path(filepath)
+            print(f"Deleted {filepath}")
+
+    request.addfinalizer(cleanup)
+    return add_file
+
+
+# create fixtures for each mock records list, to avoid different tests
+# collidiing with each other.
+@pytest.fixture
+def mock_follow_records_fixture():
+    return copy.deepcopy(mock_follow_records)
+
+
+@pytest.fixture
+def mock_like_records_fixture():
+    return copy.deepcopy(mock_like_records)
+
+
+@pytest.fixture
+def mock_post_records_fixture():
+    return copy.deepcopy(mock_post_records)
+
+
+class TestManageFollow:
+    """Tests for manage_follow.
+
+    Checks that the files are written locally as intended, and then deletes them.
+    """
+
+    def test_manage_follow_create_default(self, mock_follow_records_fixture):
+        """Test manage_follow for 'create' operation (for a generic follow record)."""  # noqa
+        relative_filepath = export_filepath_map["create"]["follow"]
+        mock_follower_did = "did:plc:generic-user-2"
+        mock_followee_did = "did:plc:generic-user-1"
+        expected_filename = f"follower_did={mock_follower_did}_followee_did={mock_followee_did}.json"  # noqa
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_follow(follow=mock_follow_records_fixture[0], operation="create")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_manage_follow_delete_default(self, mock_follow_records_fixture):
+        """Test manage_follow for 'delete' operation (for a generic follow record)."""  # noqa
+        relative_filepath = export_filepath_map["delete"]["follow"]
+        mock_follow_uri_suffix = "random-hash"
+        expected_filename = f"follow_uri_suffix={mock_follow_uri_suffix}.json"
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_follow(follow=mock_follow_records_fixture[0], operation="delete")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_study_user_is_follower(self, mock_study_user_manager, mock_follow_records_fixture):
+        """Tests logic for when a study user is following another account.
+
+        Expects that two filepaths are written:
+        - One for all the 'follow' records.
+        - One for the 'follow' records of study participants.
+        """
+        relative_filepath_1 = export_filepath_map["create"]["follow"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["follow"]["follower"]  # noqa
+        mock_follower_did = "did:plc:study-user-1"
+        mock_followee_did = "did:plc:generic-user-1"
+        expected_filename = f"follower_did={mock_follower_did}_followee_did={mock_followee_did}.json"  # noqa
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_follower_did,
+            relative_filepath_2,
+            expected_filename
+        )
+
+        # run check.
+        manage_follow(follow=mock_follow_records_fixture[2], operation="create")
+
+        # check that the files were written.
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+    def test_study_user_is_followed(self, mock_study_user_manager, mock_follow_records_fixture):
+        """Tests logic for when a study user is being followed by another account.
+
+        Expects that two filepaths are written:
+        - One for all the 'follow' records.
+        - One for the 'follow' records of study participants.
+        """  # noqa
+        relative_filepath_1 = export_filepath_map["create"]["follow"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["follow"]["followee"]  # noqa
+        mock_follower_did = "did:plc:generic-user-1"
+        mock_followee_did = "did:plc:study-user-1"
+        expected_filename = f"follower_did={mock_follower_did}_followee_did={mock_followee_did}.json"  # noqa
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_followee_did,
+            relative_filepath_2,
+            expected_filename
+        )
+
+        # run check.
+        manage_follow(follow=mock_follow_records_fixture[1], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+
+class TestManageFollows:
+    """Tests for manage_follows."""
+
+    def test_manage_follows(self, mock_study_user_manager, mock_follow_records_fixture):
+        """Test manage_follows."""
+        # we really only need to test 'created' records since this is the
+        # one that's more important (and by far, more common).
+        follows = {"created": mock_follow_records_fixture, "deleted": []}
+
+        # we have 3 follow records, a default, and two for study users.
+        # we expect 5 records: 3 in the default path and 2 in the study user
+        # acitvities path.
+        default_relative_filepath = export_filepath_map["create"]["follow"]
+        study_user_relative_fp_1 = study_user_activity_relative_path_map["create"]["follow"]["followee"]
+        study_user_relative_fp_2 = study_user_activity_relative_path_map["create"]["follow"]["follower"]
+
+        mock_follower_did_1 = "did:plc:generic-user-2"
+        mock_followee_did_1 = "did:plc:generic-user-1"
+
+        mock_follower_did_2 = "did:plc:generic-user-1"
+        mock_followee_did_2 = "did:plc:study-user-1"
+
+        mock_follower_did_3 = "did:plc:study-user-1"
+        mock_followee_did_3 = "did:plc:generic-user-1"
+
+        expected_filename_1 = f"follower_did={mock_follower_did_1}_followee_did={mock_followee_did_1}.json"  # noqa
+        expected_filename_2 = f"follower_did={mock_follower_did_2}_followee_did={mock_followee_did_2}.json"  # noqa
+        expected_filename_3 = f"follower_did={mock_follower_did_3}_followee_did={mock_followee_did_3}.json"  # noqa
+
+        # default filepaths
+        expected_default_filepath_1 = os.path.join(default_relative_filepath, expected_filename_1)
+        expected_default_filepath_2 = os.path.join(default_relative_filepath, expected_filename_2)
+        expected_default_filepath_3 = os.path.join(default_relative_filepath, expected_filename_3)
+
+        # study user filepaths
+        expected_study_user_filepath_1 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_followee_did_2,
+            study_user_relative_fp_1,
+            expected_filename_2
+        )
+        expected_study_user_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_follower_did_3,
+            study_user_relative_fp_2,
+            expected_filename_3
+        )
+
+        manage_follows(follows=follows)
+
+        # check default path. Should be 3 files.
+        assert os.path.exists(expected_default_filepath_1)
+        clean_path(expected_default_filepath_1)
+
+        assert os.path.exists(expected_default_filepath_2)
+        clean_path(expected_default_filepath_2)
+
+        assert os.path.exists(expected_default_filepath_3)
+        clean_path(expected_default_filepath_3)
+
+        # check user activities path. Should be two files.
+        assert os.path.exists(expected_study_user_filepath_1)  # user is followee
+        clean_path(expected_study_user_filepath_1)
+
+        assert os.path.exists(expected_study_user_filepath_2)  # user is follower
+        clean_path(expected_study_user_filepath_2)
+
+
+class TestManageLike:
+    """Tests for manage_like."""
+
+    def test_manage_create_default_like(self, mock_like_records_fixture):
+        relative_filepath = export_filepath_map["create"]["like"]
+        mock_author_did = "did:plc:generic-user-1"
+        mock_uri_suffix = "like-record-suffix-123"
+        expected_filename = f"like_author_did={mock_author_did}_like_uri_suffix={mock_uri_suffix}.json"
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_like(like=mock_like_records_fixture[0], operation="create")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_manage_delete_default_like(self, mock_like_records_fixture):
+        relative_filepath = export_filepath_map["delete"]["like"]
+        mock_uri_suffix = "like-record-suffix-123"
+        expected_filename = f"like_uri_suffix={mock_uri_suffix}.json"
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_like(like=mock_like_records_fixture[0], operation="delete")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_study_user_likes_post(self, mock_study_user_manager, mock_like_records_fixture):
+        """Tests case where the study user likes a post.
+
+        Should create two files:
+        - One in the default path.
+        - One in the study user activities path.
+        """
+        relative_filepath_1 = export_filepath_map["create"]["like"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["like"]
+        mock_author_did = "did:plc:study-user-1"
+        mock_liked_post_uri_suffix = "generic-post-uri-1"
+        mock_like_uri_suffix = "like-record-suffix-456"
+
+        expected_filename = f"like_author_did={mock_author_did}_like_uri_suffix={mock_like_uri_suffix}.json"
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_author_did,
+            relative_filepath_2,
+            mock_liked_post_uri_suffix,
+            expected_filename
+        )
+
+        manage_like(like=mock_like_records_fixture[1], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+    def test_study_user_post_is_liked(self, mock_study_user_manager, mock_like_records_fixture):
+        """Tests the case where a study user's post is liked."""
+        relative_filepath_1 = export_filepath_map["create"]["like"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["like_on_user_post"]
+        mock_author_did = "did:plc:generic-user-1"
+        mock_liked_post_author_did = "did:plc:study-user-2"
+        mock_liked_post_uri_suffix = "post-uri-2"
+        mock_like_uri_suffix = "like-record-suffix-789"
+        expected_filename = f"like_author_did={mock_author_did}_like_uri_suffix={mock_like_uri_suffix}.json"
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_liked_post_author_did,
+            relative_filepath_2,
+            mock_liked_post_uri_suffix,
+            expected_filename
+        )
+
+        manage_like(like=mock_like_records_fixture[2], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+
+class TestManageLikes:
+    """Tests for manage_likes."""
+
+    def test_manage_likes(self, mock_study_user_manager, mock_like_records_fixture):
+        """Test manage_likes.
+
+        We only care about 'created' records.
+        """
+        likes = {"created": mock_like_records_fixture, "deleted": []}
+
+        # we have 3 like records, one default, one where a study user likes a
+        # post, and one where a post by a study user is liked.
+
+        # we expect 3 files in the default path and 2 in the study user activities
+        default_relative_filepath = export_filepath_map["create"]["like"]
+
+        # URIs of like records themselves (not the posts).
+        like_uri_suffix_1 = "like-record-suffix-123"
+        like_uri_suffix_2 = "like-record-suffix-456"
+        like_uri_suffix_3 = "like-record-suffix-789"
+
+        # expected filenames in the default paths (3)
+        mock_author_did_1 = "did:plc:generic-user-1"
+        mock_author_did_2 = "did:plc:study-user-1"
+        mock_author_did_3 = "did:plc:generic-user-1"
+
+        expected_default_filename_1 = f"like_author_did={mock_author_did_1}_like_uri_suffix={like_uri_suffix_1}.json"
+        expected_default_filename_2 = f"like_author_did={mock_author_did_2}_like_uri_suffix={like_uri_suffix_2}.json"
+        expected_default_filename_3 = f"like_author_did={mock_author_did_3}_like_uri_suffix={like_uri_suffix_3}.json"
+
+        expected_default_filepath_1 = os.path.join(
+            default_relative_filepath, expected_default_filename_1
+        )
+        expected_default_filepath_2 = os.path.join(
+            default_relative_filepath, expected_default_filename_2
+        )
+        expected_default_filepath_3 = os.path.join(
+            default_relative_filepath, expected_default_filename_3
+        )
+
+        # expected filenames in the study user activities path.
+
+        # we only care about the URI of the actual liked post if the actual liked
+        # post was written by a study user.
+        mock_liked_post_uri_suffix_1 = "generic-post-uri-1"  # study user likes a post
+        mock_liked_post_uri_suffix_2 = "post-uri-2"  # someone likes a study user's post # noqa
+        mock_liked_post_author_did_2 = "did:plc:study-user-2"
+
+        study_user_relative_fp_1 = os.path.join(
+            study_user_activity_relative_path_map["create"]["like"],
+            mock_liked_post_uri_suffix_1
+        )
+        study_user_relative_fp_2 = os.path.join(
+            study_user_activity_relative_path_map["create"]["like_on_user_post"],
+            mock_liked_post_uri_suffix_2
+        )
+
+        expected_study_user_filepath_1 = os.path.join(  # study user likes a post
+            study_user_activity_root_local_path,
+            mock_author_did_2,
+            study_user_relative_fp_1,
+            expected_default_filename_2
+        )
+        expected_study_user_filepath_2 = os.path.join(  # someone likes a study user's post # noqa
+            study_user_activity_root_local_path,
+            mock_liked_post_author_did_2,
+            study_user_relative_fp_2,
+            expected_default_filename_3
+        )
+
+        manage_likes(likes=likes)
+
+        # check default path. Should be 3 files.
+        assert os.path.exists(expected_default_filepath_1)
+        clean_path(expected_default_filepath_1)
+
+        assert os.path.exists(expected_default_filepath_2)
+        clean_path(expected_default_filepath_2)
+
+        assert os.path.exists(expected_default_filepath_3)
+        clean_path(expected_default_filepath_3)
+
+        # check user activities path. Should be two files.
+        assert os.path.exists(expected_study_user_filepath_1)
+        clean_path(expected_study_user_filepath_1)
+
+        assert os.path.exists(expected_study_user_filepath_2)
+        clean_path(expected_study_user_filepath_2)
+
+
+class TestManagePost:
+    """Tests for manage_post."""
+
+    def test_manage_post_create_default(self, mock_post_records_fixture):
+        """Tests the creation of a default post from the firehose."""
+        relative_filepath = export_filepath_map["create"]["post"]
+        mock_author_did = "did:plc:generic-user-1"
+        mock_post_uri_suffix = "post-uri-1"
+        expected_filename = f"author_did={mock_author_did}_post_uri_suffix={mock_post_uri_suffix}.json"  # noqa
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_post(post=mock_post_records_fixture[0], operation="create")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_manage_post_delete_default(self, mock_post_records_fixture):
+        """Tests the deletion of a default post from the firehose."""
+        relative_filepath = export_filepath_map["delete"]["post"]
+        mock_post_uri_suffix = "post-uri-1"
+        expected_filename = f"post_uri_suffix={mock_post_uri_suffix}.json"
+        expected_filepath = os.path.join(relative_filepath, expected_filename)
+
+        manage_post(post=mock_post_records_fixture[0], operation="delete")
+        assert os.path.exists(expected_filepath)
+        clean_path(expected_filepath)
+
+    def test_study_user_writes_post(self, mock_study_user_manager, mock_post_records_fixture):
+        """Tests the case where a study user writes a post.
+
+        Expects that two files are written:
+        - One in the default path.
+        - One in the study user activities path.
+        """
+        mock_author_did = "did:plc:study-user-1"
+        mock_post_uri_suffix = "post-uri-1"
+        relative_filepath_1 = export_filepath_map["create"]["post"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["post"]
+        expected_filename = f"author_did={mock_author_did}_post_uri_suffix={mock_post_uri_suffix}.json"  # noqa
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_author_did,
+            relative_filepath_2,
+            expected_filename
+        )
+
+        manage_post(post=mock_post_records_fixture[1], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+    def test_post_in_same_thread_as_study_user_post_parent(self, mock_study_user_manager, mock_post_records_fixture):
+        """Tests the case where a post is in the same thread as a post written
+        by a study user and that the study user post is the direct parent of
+        the post, or the post that the post is responding to.
+
+        Expects that two files are written:
+        - One in the default path.
+        - One in the study user activities path.
+        """
+        mock_author_did = "did:plc:generic-user-1"
+        mock_parent_post_author_did = "did:plc:study-user-1"
+        mock_post_uri_suffix = "generic-post-uri-1"
+        mock_original_study_user_post_uri_suffix = "post-uri-1"
+
+        # check for 2 files.
+        relative_filepath_1 = export_filepath_map["create"]["post"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["reply_to_user_post"]
+
+        expected_filename = f"author_did={mock_author_did}_post_uri_suffix={mock_post_uri_suffix}.json"
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_parent_post_author_did,  # the author of the parent post (the study user) # noqa
+            relative_filepath_2,
+            mock_original_study_user_post_uri_suffix,
+            expected_filename
+        )
+
+        manage_post(post=mock_post_records_fixture[2], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+    def test_post_in_same_thread_as_study_user_post_root(self, mock_study_user_manager, mock_post_records_fixture):
+        """Tests the case where a post is in the same thread as a post written
+        by a study user and that the study user post is the root post of the
+        thread, or the first post in the thread.
+
+        Expects that two files are written:
+        - One in the default path.
+        - One in the study user activities path.
+        """
+        mock_author_did = "did:plc:generic-user-1"
+        mock_root_post_author_did = "did:plc:study-user-1"
+        mock_post_uri_suffix = "generic-post-uri-1"
+        mock_original_study_user_post_uri_suffix = "post-uri-1"
+
+        # check for 2 files.
+        relative_filepath_1 = export_filepath_map["create"]["post"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["reply_to_user_post"]
+
+        expected_filename = f"author_did={mock_author_did}_post_uri_suffix={mock_post_uri_suffix}.json"
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_root_post_author_did,  # the author of the root post (the study user) # noqa
+            relative_filepath_2,
+            mock_original_study_user_post_uri_suffix,
+            expected_filename
+        )
+
+        manage_post(post=mock_post_records_fixture[3], operation="create")
+
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+
+class TestManagePosts:
+    """Tests for manage_posts."""
+
+    def test_manage_posts(self, mock_study_user_manager, mock_post_records_fixture):
+        """Test manage_posts.
+
+        We only care about 'created' records.
+        """
+        posts = {"created": mock_post_records_fixture, "deleted": []}
+
+        # we have 4 records, one default, one where a study user writes a post,
+        # one where a post is in the same thread as a post written by a
+        # study user (and the study user's post is the parent of the post), and
+        # one where a post is in the same thread as a post written by a study
+        # user (and the study user's post is the root of the thread).
+        default_relative_filepath = export_filepath_map["create"]["post"]
+        study_user_relative_fp_1 = study_user_activity_relative_path_map["create"]["post"]
+        study_user_relative_fp_2 = study_user_activity_relative_path_map["create"]["reply_to_user_post"]
+
+        # Post 1: generic post record
+        mock_author_did_1 = "did:plc:generic-user-1"
+        mock_post_uri_suffix_1 = "post-uri-1"
+        expected_filename_1 = f"author_did={mock_author_did_1}_post_uri_suffix={mock_post_uri_suffix_1}.json"  # noqa
+
+        # Post 2: post from a study user
+        mock_author_did_2 = "did:plc:study-user-1"
+        mock_post_uri_suffix_2 = "post-uri-1"
+        expected_filename_2 = f"author_did={mock_author_did_2}_post_uri_suffix={mock_post_uri_suffix_2}.json"  # noqa
+
+        # Post 3: post in the same thread as a post written by a study user
+        # (study user's post is the parent of the post)
+        mock_author_did_3 = "did:plc:generic-user-1"  # should be the author of the parent post
+        mock_post_uri_suffix_3 = "generic-post-uri-1"
+        mock_original_study_user_post_author_did_3 = "did:plc:study-user-1"
+        mock_original_study_user_post_uri_suffix_3 = "post-uri-1"
+        expected_filename_3 = f"author_did={mock_author_did_3}_post_uri_suffix={mock_post_uri_suffix_3}.json"
+
+        # Post 4: post in the same thread as a post written by a study user
+        # (study user's post is the root of the thread)
+        mock_author_did_4 = "did:plc:generic-user-1"  # should be the author of the parent post
+        mock_post_uri_suffix_4 = "generic-post-uri-1"
+        mock_original_study_user_post_author_did_4 = "did:plc:study-user-1"
+        mock_original_study_user_post_uri_suffix_4 = "post-uri-1"
+        expected_filename_4 = f"author_did={mock_author_did_4}_post_uri_suffix={mock_post_uri_suffix_4}.json"
+
+        # expected filenames in the default paths (4)
+        expected_default_filepath_1 = os.path.join(default_relative_filepath, expected_filename_1)
+        expected_default_filepath_2 = os.path.join(default_relative_filepath, expected_filename_2)
+        expected_default_filepath_3 = os.path.join(default_relative_filepath, expected_filename_3)
+        expected_default_filepath_4 = os.path.join(default_relative_filepath, expected_filename_4)
+
+        # expected filenames in the study user activities path (3) - one for the
+        # post written by the study user, and two for the posts that are in the
+        # same thread as the study user's posts.
+        expected_study_user_filepath_1 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_author_did_2,
+            study_user_relative_fp_1,
+            expected_filename_2
+        )
+        expected_study_user_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_original_study_user_post_author_did_3,  # author of the parent post (who is in the study)
+            study_user_relative_fp_2,
+            mock_original_study_user_post_uri_suffix_3,
+            expected_filename_3
+        )
+        expected_study_user_filepath_3 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_original_study_user_post_author_did_4,  # author of the root post (who is in the study)
+            study_user_relative_fp_2,
+            mock_original_study_user_post_uri_suffix_4,
+            expected_filename_4
+        )
+
+        manage_posts(posts=posts)
+
+        # check default path. Should be 3 files:
+        # 1. generic post record
+        # 2. post from a study user
+        # 3. post in the same thread as a post written by a study user
+        # (whether the post is a parent or root of the thread creates the same
+        # record, so when we delete the file, we only need to check for one.
+        # we write the same exact file regardless of if the post is a
+        # parent or root of the thread).
+        assert os.path.exists(expected_default_filepath_1)
+        clean_path(expected_default_filepath_1)
+
+        assert os.path.exists(expected_default_filepath_2)
+        clean_path(expected_default_filepath_2)
+
+        assert os.path.exists(expected_default_filepath_3)
+        assert os.path.exists(expected_default_filepath_4)  # same as expected_default_filepath_3
+        clean_path(expected_default_filepath_3)
+
+        # check user activities path. Should be two files.
+        # 1. post from a study user
+        # 2. post in the same thread as a post written by a study user
+        # (whether the post is a parent or root of the thread creates the same
+        # record, so when we delete the file, we only need to check for one.)
+        assert os.path.exists(expected_study_user_filepath_1)
+        clean_path(expected_study_user_filepath_1)
+
+        assert os.path.exists(expected_study_user_filepath_2)
+        assert os.path.exists(expected_study_user_filepath_3)  # same as expected_study_user_filepath_2
+        clean_path(expected_study_user_filepath_2)

--- a/services/sync/stream/tests/test_data_filter.py
+++ b/services/sync/stream/tests/test_data_filter.py
@@ -42,39 +42,9 @@ class TestManageFollow:
         expected_filename = f"follow_uri_suffix={mock_follow_uri_suffix}.json"
         expected_filepath = os.path.join(relative_filepath, expected_filename)
 
-        manage_follow(follow=mock_follow_records_fixture[0], operation="delete")
+        manage_follow(follow=mock_follow_records_fixture[1], operation="delete")
         assert os.path.exists(expected_filepath)
         clean_path(expected_filepath)
-
-    def test_study_user_is_follower(self, mock_study_user_manager, mock_follow_records_fixture):
-        """Tests logic for when a study user is following another account.
-
-        Expects that two filepaths are written:
-        - One for all the 'follow' records.
-        - One for the 'follow' records of study participants.
-        """
-        relative_filepath_1 = export_filepath_map["create"]["follow"]
-        relative_filepath_2 = study_user_activity_relative_path_map["create"]["follow"]["follower"]  # noqa
-        mock_follower_did = "did:plc:study-user-1"
-        mock_followee_did = "did:plc:generic-user-1"
-        expected_filename = f"follower_did={mock_follower_did}_followee_did={mock_followee_did}.json"  # noqa
-        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
-        expected_filepath_2 = os.path.join(
-            study_user_activity_root_local_path,
-            mock_follower_did,
-            relative_filepath_2,
-            expected_filename
-        )
-
-        # run check.
-        manage_follow(follow=mock_follow_records_fixture[2], operation="create")
-
-        # check that the files were written.
-        assert os.path.exists(expected_filepath_1)
-        clean_path(expected_filepath_1)
-
-        assert os.path.exists(expected_filepath_2)
-        clean_path(expected_filepath_2)
 
     def test_study_user_is_followed(self, mock_study_user_manager, mock_follow_records_fixture):
         """Tests logic for when a study user is being followed by another account.
@@ -97,8 +67,38 @@ class TestManageFollow:
         )
 
         # run check.
-        manage_follow(follow=mock_follow_records_fixture[1], operation="create")
+        manage_follow(follow=mock_follow_records_fixture[2], operation="create")
 
+        assert os.path.exists(expected_filepath_1)
+        clean_path(expected_filepath_1)
+
+        assert os.path.exists(expected_filepath_2)
+        clean_path(expected_filepath_2)
+
+    def test_study_user_is_follower(self, mock_study_user_manager, mock_follow_records_fixture):
+        """Tests logic for when a study user is following another account.
+
+        Expects that two filepaths are written:
+        - One for all the 'follow' records.
+        - One for the 'follow' records of study participants.
+        """
+        relative_filepath_1 = export_filepath_map["create"]["follow"]
+        relative_filepath_2 = study_user_activity_relative_path_map["create"]["follow"]["follower"]  # noqa
+        mock_follower_did = "did:plc:study-user-1"
+        mock_followee_did = "did:plc:generic-user-1"
+        expected_filename = f"follower_did={mock_follower_did}_followee_did={mock_followee_did}.json"  # noqa
+        expected_filepath_1 = os.path.join(relative_filepath_1, expected_filename)
+        expected_filepath_2 = os.path.join(
+            study_user_activity_root_local_path,
+            mock_follower_did,
+            relative_filepath_2,
+            expected_filename
+        )
+
+        # run check.
+        manage_follow(follow=mock_follow_records_fixture[3], operation="create")
+
+        # check that the files were written.
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
 
@@ -113,50 +113,65 @@ class TestManageFollows:
         """Test manage_follows."""
         # we really only need to test 'created' records since this is the
         # one that's more important (and by far, more common).
-        follows = {"created": mock_follow_records_fixture, "deleted": []}
+        follows = {
+            "created": [
+                mock_follow_records_fixture[0],
+                mock_follow_records_fixture[2],
+                mock_follow_records_fixture[3]
+            ],
+            "deleted": [mock_follow_records_fixture[1]]
+        }
 
-        # we have 3 follow records, a default, and two for study users.
-        # we expect 5 records: 3 in the default path and 2 in the study user
+        # we have 4 follow records, a default create and delete, and two for
+        # study users.
+        # we expect 6 records: 4 in the default path and 2 in the study user
         # acitvities path.
-        default_relative_filepath = export_filepath_map["create"]["follow"]
+        default_relative_create_filepath = export_filepath_map["create"]["follow"]
+        default_relative_delete_filepath = export_filepath_map["delete"]["follow"]
+
         study_user_relative_fp_1 = study_user_activity_relative_path_map["create"]["follow"]["followee"]
         study_user_relative_fp_2 = study_user_activity_relative_path_map["create"]["follow"]["follower"]
 
         mock_follower_did_1 = "did:plc:generic-user-2"
         mock_followee_did_1 = "did:plc:generic-user-1"
 
-        mock_follower_did_2 = "did:plc:generic-user-1"
-        mock_followee_did_2 = "did:plc:study-user-1"
+        mock_follower_did_3 = "did:plc:generic-user-1"
+        mock_followee_did_3 = "did:plc:study-user-1"
 
-        mock_follower_did_3 = "did:plc:study-user-1"
-        mock_followee_did_3 = "did:plc:generic-user-1"
+        mock_follower_did_4 = "did:plc:study-user-1"
+        mock_followee_did_4 = "did:plc:generic-user-1"
+
+        deleted_file_mock_uri_suffix = "random-hash"
 
         expected_filename_1 = f"follower_did={mock_follower_did_1}_followee_did={mock_followee_did_1}.json"  # noqa
-        expected_filename_2 = f"follower_did={mock_follower_did_2}_followee_did={mock_followee_did_2}.json"  # noqa
+        expected_filename_2 = f"follow_uri_suffix={deleted_file_mock_uri_suffix}.json"  # noqa
+
         expected_filename_3 = f"follower_did={mock_follower_did_3}_followee_did={mock_followee_did_3}.json"  # noqa
+        expected_filename_4 = f"follower_did={mock_follower_did_4}_followee_did={mock_followee_did_4}.json"  # noqa
 
         # default filepaths
-        expected_default_filepath_1 = os.path.join(default_relative_filepath, expected_filename_1)
-        expected_default_filepath_2 = os.path.join(default_relative_filepath, expected_filename_2)
-        expected_default_filepath_3 = os.path.join(default_relative_filepath, expected_filename_3)
+        expected_default_filepath_1 = os.path.join(default_relative_create_filepath, expected_filename_1)
+        expected_default_filepath_2 = os.path.join(default_relative_delete_filepath, expected_filename_2)
+        expected_default_filepath_3 = os.path.join(default_relative_create_filepath, expected_filename_3)
+        expected_default_filepath_4 = os.path.join(default_relative_create_filepath, expected_filename_4)
 
         # study user filepaths
         expected_study_user_filepath_1 = os.path.join(
             study_user_activity_root_local_path,
-            mock_followee_did_2,
+            mock_followee_did_3,
             study_user_relative_fp_1,
-            expected_filename_2
+            expected_filename_3
         )
         expected_study_user_filepath_2 = os.path.join(
             study_user_activity_root_local_path,
-            mock_follower_did_3,
+            mock_follower_did_4,
             study_user_relative_fp_2,
-            expected_filename_3
+            expected_filename_4
         )
 
         manage_follows(follows=follows)
 
-        # check default path. Should be 3 files.
+        # check default path. Should be 4 files.
         assert os.path.exists(expected_default_filepath_1)
         clean_path(expected_default_filepath_1)
 
@@ -165,6 +180,9 @@ class TestManageFollows:
 
         assert os.path.exists(expected_default_filepath_3)
         clean_path(expected_default_filepath_3)
+
+        assert os.path.exists(expected_default_filepath_4)
+        clean_path(expected_default_filepath_4)
 
         # check user activities path. Should be two files.
         assert os.path.exists(expected_study_user_filepath_1)  # user is followee
@@ -194,7 +212,7 @@ class TestManageLike:
         expected_filename = f"like_uri_suffix={mock_uri_suffix}.json"
         expected_filepath = os.path.join(relative_filepath, expected_filename)
 
-        manage_like(like=mock_like_records_fixture[0], operation="delete")
+        manage_like(like=mock_like_records_fixture[1], operation="delete")
         assert os.path.exists(expected_filepath)
         clean_path(expected_filepath)
 
@@ -221,7 +239,7 @@ class TestManageLike:
             expected_filename
         )
 
-        manage_like(like=mock_like_records_fixture[1], operation="create")
+        manage_like(like=mock_like_records_fixture[2], operation="create")
 
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
@@ -247,7 +265,7 @@ class TestManageLike:
             expected_filename
         )
 
-        manage_like(like=mock_like_records_fixture[2], operation="create")
+        manage_like(like=mock_like_records_fixture[3], operation="create")
 
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
@@ -264,7 +282,15 @@ class TestManageLikes:
 
         We only care about 'created' records.
         """
-        likes = {"created": mock_like_records_fixture, "deleted": []}
+        # skip the deleted record.
+        likes = {
+            "created": [
+                mock_like_records_fixture[0],
+                mock_like_records_fixture[2],
+                mock_like_records_fixture[3]
+            ],
+            "deleted": []
+        }
 
         # we have 3 like records, one default, one where a study user likes a
         # post, and one where a post by a study user is liked.
@@ -368,7 +394,7 @@ class TestManagePost:
         expected_filename = f"post_uri_suffix={mock_post_uri_suffix}.json"
         expected_filepath = os.path.join(relative_filepath, expected_filename)
 
-        manage_post(post=mock_post_records_fixture[0], operation="delete")
+        manage_post(post=mock_post_records_fixture[1], operation="delete")
         assert os.path.exists(expected_filepath)
         clean_path(expected_filepath)
 
@@ -392,7 +418,7 @@ class TestManagePost:
             expected_filename
         )
 
-        manage_post(post=mock_post_records_fixture[1], operation="create")
+        manage_post(post=mock_post_records_fixture[2], operation="create")
 
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
@@ -428,7 +454,7 @@ class TestManagePost:
             expected_filename
         )
 
-        manage_post(post=mock_post_records_fixture[2], operation="create")
+        manage_post(post=mock_post_records_fixture[3], operation="create")
 
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
@@ -464,7 +490,7 @@ class TestManagePost:
             expected_filename
         )
 
-        manage_post(post=mock_post_records_fixture[3], operation="create")
+        manage_post(post=mock_post_records_fixture[4], operation="create")
 
         assert os.path.exists(expected_filepath_1)
         clean_path(expected_filepath_1)
@@ -481,7 +507,15 @@ class TestManagePosts:
 
         We only care about 'created' records.
         """
-        posts = {"created": mock_post_records_fixture, "deleted": []}
+        posts = {
+            "created": [
+                mock_post_records_fixture[0],
+                mock_post_records_fixture[2],
+                mock_post_records_fixture[3],
+                mock_post_records_fixture[4]
+            ],
+            "deleted": []  # skip the deleted record.
+        }
 
         # we have 4 records, one default, one where a study user writes a post,
         # one where a post is in the same thread as a post written by a

--- a/services/sync/stream/tests/test_export_data.py
+++ b/services/sync/stream/tests/test_export_data.py
@@ -27,10 +27,35 @@ class TestExportStudyUserActivityLocalData:
         self, mock_follow_records_fixture, mock_like_records_fixture,
         mock_post_records_fixture, mock_s3_fixture, mock_study_user_manager
     ):
+        # skip deleted records. We test those in individual unit tests
+        # but for e2e/integration tests we care that 'create' is implemented
+        # correctly.
         operations_by_type = {
-            "posts": {"created": mock_post_records_fixture, "deleted": []},
-            "likes": {"created": mock_like_records_fixture, "deleted": []},
-            "follows": {"created": mock_follow_records_fixture, "deleted": []}
+            "posts": {
+                # skip the second post, which is the deleted post
+                "created": [
+                    post for idx, post in enumerate(mock_post_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            },
+            "likes": {
+                # skip the second like, which is the deleted like
+                "created": [
+                    like for idx, like in enumerate(mock_like_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            },
+            "follows": {
+                # skip the second follow, which is the deleted follow
+                "created": [
+                    follow for idx, follow
+                    in enumerate(mock_follow_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            }
         }
         operations_callback(operations_by_type)
 
@@ -79,10 +104,35 @@ class TestExportBatch():
         self, mock_follow_records_fixture, mock_like_records_fixture,
         mock_post_records_fixture, mock_s3_fixture, mock_study_user_manager
     ):
+        # skip deleted records. We test those in individual unit tests
+        # but for e2e/integration tests we care that 'create' is implemented
+        # correctly.
         operations_by_type = {
-            "posts": {"created": mock_post_records_fixture, "deleted": []},
-            "likes": {"created": mock_like_records_fixture, "deleted": []},
-            "follows": {"created": mock_follow_records_fixture, "deleted": []}
+            "posts": {
+                # skip the second post, which is the deleted post
+                "created": [
+                    post for idx, post in enumerate(mock_post_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            },
+            "likes": {
+                # skip the second like, which is the deleted like
+                "created": [
+                    like for idx, like in enumerate(mock_like_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            },
+            "follows": {
+                # skip the second follow, which is the deleted follow
+                "created": [
+                    follow for idx, follow
+                    in enumerate(mock_follow_records_fixture)
+                    if idx != 1
+                ],
+                "deleted": []
+            }
         }
         operations_callback(operations_by_type)
         export_batch(compressed=True, clear_cache=True, external_store=["s3"])

--- a/services/sync/stream/tests/test_export_data.py
+++ b/services/sync/stream/tests/test_export_data.py
@@ -1,0 +1,69 @@
+"""Tests for export_data.py."""
+import os
+
+import pytest
+
+from services.sync.stream.data_filter import operations_callback
+from services.sync.stream.export_data import export_study_user_activity_local_data  # noqa
+from services.sync.stream.tests.conftest import (
+    mock_follow_records_fixture, mock_like_records_fixture,
+    mock_post_records_fixture, mock_s3_fixture, mock_study_user_manager,
+    mock_s3
+)
+
+# TODO: write a function to clean up all study activity data files
+# (I need this generally, but I can also use it here as well).
+# TODO: this should fit in the functionality of clearing all the cache files,
+# and I can run that anyways.
+# TODO: I should also create a unit test for the general firehose data as well?
+
+
+class TestExportStudyUserActivityLocalData:
+    """Tests the export_study_user_activity_local_data function.
+
+    Steps:
+    1. Takes the mock data and writes it locally using the same logic as
+    what runs in the firehose (i.e., using `operations_callback` to run
+    `manage_posts`, `manage_likes`, and `manage_follows`).
+    2. Calls `export_study_user_activity_local_data` on the exported data.
+    3. Stubs the S3 call and checks to see if the correct data is uploaded.
+    """
+
+    def test_export_study_user_activity_local_data(
+        self, mock_follow_records_fixture, mock_like_records_fixture,
+        mock_post_records_fixture, mock_s3_fixture, mock_study_user_manager
+    ):
+        operations_by_type = {
+            "posts": {"created": mock_post_records_fixture, "deleted": []},
+            "likes": {"created": mock_like_records_fixture, "deleted": []},
+            "follows": {"created": mock_follow_records_fixture, "deleted": []}
+        }
+        operations_callback(operations_by_type)
+
+        # check the stubbed writes to s3 and see what the keys were that
+        # were written. Check that they match what we'd expect
+        export_study_user_activity_local_data()
+
+        actual_keys: set[str] = {
+            call_args.kwargs['key']
+            for call_args
+            in mock_s3.write_dict_json_to_s3.call_args_list
+        }
+        expected_keys = set([
+            ### did:plc:study-user-1 ###
+            ## follows ##
+            "study_user_activity/did:plc:study-user-1/create/follow/followee/follower_did=did:plc:generic-user-1_followee_did=did:plc:study-user-1.json",
+            "study_user_activity/did:plc:study-user-1/create/follow/follower/follower_did=did:plc:study-user-1_followee_did=did:plc:generic-user-1.json",
+            ## likes ##
+            "study_user_activity/did:plc:study-user-1/create/like/generic-post-uri-1/like_author_did=did:plc:study-user-1_like_uri_suffix=like-record-suffix-456.json",
+            ## post ##
+            "study_user_activity/did:plc:study-user-1/create/post/author_did=did:plc:study-user-1_post_uri_suffix=post-uri-1.json",
+            ## reply_to_user_post ##
+            "study_user_activity/did:plc:study-user-1/create/reply_to_user_post/post-uri-1/author_did=did:plc:generic-user-1_post_uri_suffix=generic-post-uri-1.json",
+            ### did:plc:study-user-2 ###
+            ## like_on_user_post ##
+            "study_user_activity/did:plc:study-user-2/create/like_on_user_post/post-uri-2/like_author_did=did:plc:generic-user-1_like_uri_suffix=like-record-suffix-789.json"
+        ])
+        assert actual_keys == expected_keys
+
+        # TODO: clear out the files that were written to the local directory


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Add-collection-of-latest-user-activity-to-sync-a2737cbb9f914a319123612d3bf37d7d?pvs=4

We can track, within the firehose logic, the posts/likes/follows that are related to the study users.

Some things that we want to track include:
- What posts did study participant write?
- What posts did the study participant like?
- Did the study participant get a new follower? Did they follow anyone new?
- Did anyone like their post?
- Did anyone retweet their post?

We could consolidate this info downstream, but:
- This feels like duplicated computation when we can just track this at the source.
- Having the raw, unaltered user activity data, instead of downstream after our preprocessing and transformations, gives us more confidence that we didn't "lose anything" in the pipeline.
- We really want to be certain that we keep all activity related to study users. We're more OK with losing a few records from the general firehose, but we really want to be 100% sure that, for example, if a user writes a post, that we know about it.
- We will still process them in preprocessing anyways.

**Implementation details**
1. We track the (1) list of users (by user DID) and (2) the posts written by users (post uri : user DID). This is in S3 and we load this in when the firehose runs. 
2. During the firehose run, we check if any of the following are true:
- A user in the study writes a new post.
- A user in the study likes a post (even their own post).
- A user in the study follows another user or is followed by a user.
- A user's post is liked by another user.
- A user replies in the same thread as a post by a user in the study.

(What I've not been able to figure out yet are reposts/retweets, but this can be revisited).
3. If any of those cases are true, we write that record (a) to the general firehose sync path and (2) to its own specific S3 path, `study_user_activity`. That way, we have a separate filepath for all activities done by users, instead of doing this processing downstream.
4. We write this locally and then, in batches, write to S3. We then clear the cache for the next batch.
5. We update a singleton instance of a post tracker that tracks which posts have been written by which users. We use this to check if a study user's posts have been liked or replied to by someone else. When we write the batch to S3, we also update this instance and update the latest hash map of post uris: user DID to S3.


**Testing plan**
1. Test individual functions. Write unit tests for all required functions.
2. Test firehose run.
- Check that all activities in general are still written to S3.
- Do activity on my personal account and see if that is recorded as intended:
(a) Write a post.
(b) Like a post.
(c) Follow a user.
(d) Like my own post (to simulate someone liking my post)
(e) Respond to my own post (to simulate someone responding to my post)

Screenshots:

_Results from general firehose run_
<img width="1500" alt="Screenshot 2024-08-02 at 10 50 01 PM" src="https://github.com/user-attachments/assets/b46da46d-014f-4c0e-82ee-1e31f212c334">

_S3 records of my own activities_
<img width="1703" alt="Screenshot 2024-08-02 at 10 51 57 PM" src="https://github.com/user-attachments/assets/fb4173d6-093e-4d38-a778-b509d6e58601">

_S3 write of my own post_
<img width="1510" alt="Screenshot 2024-08-02 at 10 50 43 PM" src="https://github.com/user-attachments/assets/391e5cb9-e5a1-49fa-be00-d2115fe26679">

_S3 record of me following a user (Billy)_
<img width="1512" alt="Screenshot 2024-08-02 at 10 51 05 PM" src="https://github.com/user-attachments/assets/85f3f9b6-6f3e-4674-94bf-9400d62c09ff">

_S3 record of Billy having a new follower (me)_
<img width="1521" alt="Screenshot 2024-08-02 at 10 51 22 PM" src="https://github.com/user-attachments/assets/85ae0918-3095-45ad-af75-02d02a2b13db">

_S3 records of posts that I liked_
<img width="1728" alt="Screenshot 2024-08-02 at 10 52 16 PM" src="https://github.com/user-attachments/assets/477f435f-d074-416b-8a20-140d484aeba1">

_S3 record of a like on my post (I liked my own post)_
<img width="1728" alt="Screenshot 2024-08-02 at 10 52 31 PM" src="https://github.com/user-attachments/assets/d2b3e98d-89f3-49ef-8407-2983f0ad1b1c">

_S3 record of a reply to a post (I replied to my own post)_
<img width="1728" alt="Screenshot 2024-08-02 at 10 52 45 PM" src="https://github.com/user-attachments/assets/d647f7eb-6e62-4581-b568-e77b9641e180">
