### PR TITLE
Containerize and deploy the sync services (firehose, most-liked)

### DIFF
--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.10-slim
 
-RUN pip install awscli
-
 WORKDIR /app
 
 # add .env env vars to the container
@@ -29,6 +27,7 @@ COPY services/participant_data/study_users.py ./services/participant_data/study_
 WORKDIR /app/pipelines/sync_post_records/firehose
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install awscli==1.33.38
 
 ENV PYTHONPATH=/app
 

--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -18,6 +18,10 @@ COPY transform/* ./transform/
 COPY services/participant_data/study_users.py ./services/participant_data/study_users.py
 COPY services/sync/stream/* ./services/sync/stream/
 COPY services/consolidate_post_records/* ./services/consolidate_post_records/
+COPY services/participant_data/helper.py ./services/participant_data/helper.py
+COPY services/participant_data/mock_users.py ./services/participant_data/mock_users.py
+COPY services/participant_data/models.py ./services/participant_data/models.py
+COPY services/participant_data/study_users.py ./services/participant_data/study_users.py
 
 WORKDIR /app/pipelines/sync_post_records/firehose
 

--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -10,6 +10,7 @@ COPY pipelines/sync_post_records/firehose ./pipelines/sync_post_records/firehose
 COPY lib/aws/*.py ./lib/aws/
 COPY lib/constants.py ./lib/constants.py
 COPY lib/db/bluesky_models/* ./lib/db/bluesky_models/
+COPY lib/db/manage_local_data.py ./lib/db/manage_local_data.py
 COPY lib/helper.py ./lib/helper.py
 COPY lib/log/logger.py ./lib/log/logger.py
 

--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -26,8 +26,7 @@ COPY services/participant_data/study_users.py ./services/participant_data/study_
 
 WORKDIR /app/pipelines/sync_post_records/firehose
 
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install awscli==1.33.38
+RUN pip install --no-cache-dir -r requirements.txt && pip install awscli==1.33.38
 
 ENV PYTHONPATH=/app
 

--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-slim
 
+RUN pip install awscli
+
 WORKDIR /app
 
 # add .env env vars to the container

--- a/Dockerfiles/sync_most_liked_feed.Dockerfile
+++ b/Dockerfiles/sync_most_liked_feed.Dockerfile
@@ -11,6 +11,7 @@ COPY pipelines/sync_post_records/most_liked ./pipelines/sync_post_records/most_l
 COPY lib/aws/*.py ./lib/aws/
 COPY lib/constants.py ./lib/constants.py
 COPY lib/db/bluesky_models/* ./lib/db/bluesky_models/
+COPY lib/db/manage_local_data.py ./lib/db/manage_local_data.py
 COPY lib/db/mongodb.py ./lib/db/mongodb.py
 COPY lib/helper.py ./lib/helper.py
 COPY lib/log/logger.py ./lib/log/logger.py
@@ -27,10 +28,12 @@ COPY transform/* ./transform/
 
 WORKDIR /app/pipelines/sync_post_records/most_liked
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Make port 80 available to the world outside this container
-EXPOSE 80
+# install packages. Install fasttext from source to avoid dependency hell
+RUN apt update && apt install -y git g++ \
+    && pip install --no-cache-dir -r requirements.txt \
+    && git clone https://github.com/facebookresearch/fastText.git \
+    && cd fastText \
+    && pip install .
 
 ENV PYTHONPATH=/app
 

--- a/lib/db/bluesky_models/transformations.py
+++ b/lib/db/bluesky_models/transformations.py
@@ -33,7 +33,7 @@ class TransformedRecordModel(BaseModel):
     reply_parent: Optional[str] = Field(default=None, description="The parent post that the record is responding to in the thread, if any.")  # noqa
     reply_root: Optional[str] = Field(default=None, description="The root post of the thread, if any.")  # noqa
     tags: Optional[str] = Field(default=None, description="The tags of the record, if any.")  # noqa
-    py_type: te.Literal["app.bsky.feed.post"] = Field(default="app.bsky.feed.post", frozen=True)  # noqa
+    py_type: Optional[te.Literal["app.bsky.feed.post"]] = Field(default="app.bsky.feed.post", frozen=True)  # noqa
 
 
 class PostMetadataModel(BaseModel):

--- a/lib/log/logger.py
+++ b/lib/log/logger.py
@@ -60,6 +60,7 @@ def get_logger(filename_dunder: str) -> Logger:
     root_idx = [
         idx for idx, word in enumerate(split_fp)
         if word == "bluesky-research" or word == "bluesky_research"
-    ][0]
+    ]
+    root_idx = root_idx[0] if root_idx else 0
     joined_fp = '/'.join(word for word in split_fp[root_idx:])
     return Logger(name=joined_fp)

--- a/pipelines/sync_post_records/firehose/requirements.in
+++ b/pipelines/sync_post_records/firehose/requirements.in
@@ -1,5 +1,5 @@
-atproto==0.0.46
-boto3==1.34.104
+atproto==0.0.48
+boto3==1.34.131
 flask==3.0.2
 memory_profiler==0.61.0
 pydantic==2.7.4

--- a/pipelines/sync_post_records/firehose/requirements.txt
+++ b/pipelines/sync_post_records/firehose/requirements.txt
@@ -8,11 +8,11 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
     # via httpx
-atproto==0.0.46
+atproto==0.0.48
     # via -r requirements.in
 blinker==1.8.2
     # via flask
-boto3==1.34.104
+boto3==1.34.131
     # via -r requirements.in
 botocore==1.34.137
     # via

--- a/pipelines/sync_post_records/most_liked/most_liked.py
+++ b/pipelines/sync_post_records/most_liked/most_liked.py
@@ -8,7 +8,7 @@ def get_posts() -> None:
     logger.info("Getting posts from the most liked feed.")
     try:
         args = {
-            "use_latest_local": True,
+            "use_latest_local": False,
             "store_local": True,
             "store_remote": True,
             "feeds": ["today"]

--- a/pipelines/sync_post_records/most_liked/requirements.in
+++ b/pipelines/sync_post_records/most_liked/requirements.in
@@ -1,7 +1,7 @@
 atproto==0.0.46
 boto3==1.34.104
 memory_profiler==0.61.0
-fasttext==0.9.2
+# fasttext==0.9.2
 numpy==1.26.4 # numpy=2.0.0 is the most recent version, which is a big jump.
 pydantic==2.7.4
 pymongo==4.7.1

--- a/pipelines/sync_post_records/most_liked/requirements.txt
+++ b/pipelines/sync_post_records/most_liked/requirements.txt
@@ -32,8 +32,6 @@ dnspython==2.6.1
     #   pymongo
 exceptiongroup==1.2.1
     # via anyio
-fasttext==0.9.2
-    # via -r requirements.in
 h11==0.14.0
     # via httpcore
 httpcore==1.0.5
@@ -53,13 +51,9 @@ libipld==1.2.3
 memory-profiler==0.61.0
     # via -r requirements.in
 numpy==1.26.4
-    # via
-    #   -r requirements.in
-    #   fasttext
+    # via -r requirements.in
 psutil==6.0.0
     # via memory-profiler
-pybind11==2.13.1
-    # via fasttext
 pycparser==2.22
     # via cffi
 pydantic==2.7.4
@@ -93,6 +87,3 @@ urllib3==2.2.2
     # via botocore
 websockets==12.0
     # via atproto
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/scripts/run_docker_container.sh
+++ b/scripts/run_docker_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs the Docker container for the firehose sync service.
+
+# Will eventually be ported over to Singularity.
+
+# Run the Docker container and mount the AWS credentials
+image_name=$1
+if [ -z "$image_name" ]; then
+    echo "No image name provided. Using default image name 'sync_firehose_stream'."
+    image_name="sync_firehose_stream"
+fi
+
+docker run -v ~/.aws:/root/.aws -v ~/.aws/sso/cache:/root/.aws/sso/cache $image_name

--- a/scripts/run_firehose_docker.sh
+++ b/scripts/run_firehose_docker.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Runs the Docker container for the firehose sync service.
-
-# Will eventually be ported over to Singularity.
-
-# Run the Docker container and mount the AWS credentials
-docker run -v ~/.aws:/root/.aws sync_firehose_stream

--- a/scripts/run_firehose_docker.sh
+++ b/scripts/run_firehose_docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Runs the Docker container for the firehose sync service.
+
+# Will eventually be ported over to Singularity.
+
+# Run the Docker container and mount the AWS credentials
+docker run -v ~/.aws:/root/.aws sync_firehose_stream

--- a/services/sync/stream/export_data.py
+++ b/services/sync/stream/export_data.py
@@ -44,6 +44,7 @@ import json
 import os
 import shutil
 from typing import Literal, Optional
+import uuid
 
 from lib.aws.dynamodb import DynamoDB
 from lib.aws.s3 import S3
@@ -168,7 +169,7 @@ def compress_cached_files_and_write_to_storage(
     partition_key = S3.create_partition_key_based_on_timestamp(
         timestamp_str=timestamp_str
     )
-    filename = f"{timestamp_str}.jsonl"
+    filename = f"{timestamp_str}-{str(uuid.uuid4())}.jsonl"
     s3_export_key = s3_export_key_map[operation][operation_type]
     full_key = os.path.join(s3_export_key, partition_key, filename)
     if external_store == "s3":

--- a/services/sync/stream/firehose.py
+++ b/services/sync/stream/firehose.py
@@ -24,10 +24,10 @@ from services.sync.stream.export_data import (
 # 50,000 posts, took about 2 hours to stream (3pm-5pm Eastern Time)
 # stream_limit = 250000
 # 150,000 posts expected.
-stream_limit = 750000
+# stream_limit = 750000
 
 # how often to (1) write to S3 and (2) update the cursor state
-cursor_update_frequency = 250
+cursor_update_frequency = 5000
 
 
 def _get_ops_by_type(commit: models.ComAtprotoSyncSubscribeRepos.Commit) -> dict:  # noqa
@@ -172,7 +172,7 @@ def _run(
                     FirehoseSubscriptionStateCursorModel(**cursor_state)
                 )
                 update_cursor_state_s3(cursor_state_model)
-            if counter.get_value() > stream_limit:
-                sys.exit(0)
+            # if counter.get_value() > stream_limit:
+            #     sys.exit(0)
 
     firehose_client.start(on_message_handler)

--- a/transform/transform_raw_data.py
+++ b/transform/transform_raw_data.py
@@ -193,9 +193,11 @@ def process_facet(facet: Facet) -> str:
     features_list = []
 
     for feature in features:
+        # noticed a #Tag, so lowering manually to avoid errors while maintaining
+        # backwards compatibility.
         if (
             isinstance(feature, Tag)
-            or get_object_type_str(feature) == "app.bsky.richtext.facet#tag"
+            or get_object_type_str(feature).lower() == "app.bsky.richtext.facet#tag"
         ):
             features_list.append(process_hashtag(feature))
         elif (


### PR DESCRIPTION
Related Notion doc: 

Now that we've completed the firehose sync service [implementation](https://github.com/METResearchGroup/bluesky-research/pull/30), we can productionize.

I thought about putting it in EC2, but then I realized that I batch heavily anyways and it's $0.005 per 1,000 requests (and there's even more of a discount given that Northwestern has an agreement with AWS). If I batch every 5,000 records and there are 6M records per day max (highly overestimating, ofc), that should be 1,200 requests per day, which would be $0.006 per day or so. Very cheap! Therefore I might as well use the free compute on Quest.

This requires getting the service to work with Singularity on Quest. I confirmed it to run well locally on Docker.

**2024-08-08**
Confirmed that this works when run in a Docker container. Needs to be moved to Singularity at some point.