### PR TITLE
Set up firehose sync in EC2 instance

### DIFF
--- a/Dockerfiles/sync_firehose_stream.Dockerfile
+++ b/Dockerfiles/sync_firehose_stream.Dockerfile
@@ -26,6 +26,7 @@ COPY services/participant_data/study_users.py ./services/participant_data/study_
 
 WORKDIR /app/pipelines/sync_post_records/firehose
 
+# hadolint ignore=DL3042
 RUN pip install --no-cache-dir -r requirements.txt && pip install awscli==1.33.38
 
 ENV PYTHONPATH=/app

--- a/Dockerfiles/sync_most_liked_feed.Dockerfile
+++ b/Dockerfiles/sync_most_liked_feed.Dockerfile
@@ -29,11 +29,12 @@ COPY transform/* ./transform/
 WORKDIR /app/pipelines/sync_post_records/most_liked
 
 # install packages. Install fasttext from source to avoid dependency hell
-RUN apt update && apt install -y git g++ \
+# hadolint ignore=DL3003,DL3027
+RUN apt update && apt install -y git g++ \ 
     && pip install --no-cache-dir -r requirements.txt \
     && git clone https://github.com/facebookresearch/fastText.git \
     && cd fastText \
-    && pip install .
+    && pip install . --no-cache-dir
 
 ENV PYTHONPATH=/app
 

--- a/lib/db/bluesky_models/transformations.py
+++ b/lib/db/bluesky_models/transformations.py
@@ -33,7 +33,7 @@ class TransformedRecordModel(BaseModel):
     reply_parent: Optional[str] = Field(default=None, description="The parent post that the record is responding to in the thread, if any.")  # noqa
     reply_root: Optional[str] = Field(default=None, description="The root post of the thread, if any.")  # noqa
     tags: Optional[str] = Field(default=None, description="The tags of the record, if any.")  # noqa
-    py_type: Optional[te.Literal["app.bsky.feed.post"]] = Field(default="app.bsky.feed.post", frozen=True)  # noqa
+    py_type: Optional[te.Literal["app.bsky.feed.post", None]] = Field(default="app.bsky.feed.post", frozen=True)  # noqa
 
 
 class PostMetadataModel(BaseModel):

--- a/scripts/setup_new_firehose_ec2_instance.sh
+++ b/scripts/setup_new_firehose_ec2_instance.sh
@@ -5,34 +5,48 @@
 
 # assumes that you have the ec2 instance already spun up.
 
+# (step 0: create EC2 instance)
+aws ec2 run-instances \
+    --image-id ami-067df2907035c28c2 \
+    --count 1 \
+    --instance-type t4g.small \
+    --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=firehose-sync-ec2-instance-arm64}]' \
+    --iam-instance-profile Name=CloudWatchAgentInstanceProfile \
+    --key-name firehoseSyncEc2Key \
+	--security-group-ids sg-0b3e24638f16807d5 # "launch-wizard
+
 # 1. Set up login creds for SSH
 chmod 400 firehoseSyncEc2Key.pem
 
 # 2. SSH into the instance
 # replace with the correct instance address
-ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-222-193-178.us-east-2.compute.amazonaws.com
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-3-129-70-136.us-east-2.compute.amazonaws.com
+
 # 3. Basic setup
 sudo yum update -y
 sudo yum install git -y
 sudo yum -y install docker
-
 sudo service docker start
+
+# sudo service docker start
 sudo usermod -a -G docker ec2-user
 
 # exit instance, then SSH back in
 exit
-ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-222-193-178.us-east-2.compute.amazonaws.com
-# install Github CLI: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#amazon-linux-2-yum
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-3-129-70-136.us-east-2.compute.amazonaws.com# install Github CLI: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#amazon-linux-2-yum
 type -p yum-config-manager >/dev/null || sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo yum install gh
+
+# login to Github
+gh auth login
 
 # clone repo
 git clone https://github.com/METResearchGroup/bluesky-research.git
 
 # set up AWS access
 aws configure # use the same creds as in .aws/config
-aws sso configure # use same sso creds as in .aws/config
+aws configure sso # use the same creds as in .aws/config
 export AWS_PROFILE="AWSAdministratorAccess-517478598677"
 ACCOUNT_ID=$(aws sts get-caller-identity --profile $AWS_PROFILE --query "Account" --output text)
 
@@ -44,11 +58,51 @@ export FIREHOSE_REPO="sync_firehose_stream_service"
 docker pull ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com/$FIREHOSE_REPO:latest
 
 # set up Cloudwatch logs for Docker container
+# aws logs create-log-group --log-group-name sync-firehose-logs # should already exist.
 
-# run container
+# Install the CloudWatch agent
+sudo yum install -y amazon-cloudwatch-agent
+
+# Create the CloudWatch agent configuration file
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null <<EOL
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/lib/docker/containers/*/*.log",
+            "log_group_name": "sync-firehose-logs",
+            "log_stream_name": "{container_id}"
+          }
+        ]
+      }
+    }
+  }
+}
+EOL
+
+# Start the CloudWatch agent
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+
+# run container (with the correct AWS credentials mounted)
 export CONTAINER_NAME="sync-firehose-container"
-docker run -d --name $CONTAINER_NAME --platform linux/arm64 ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com/$FIREHOSE_REPO:latest
+docker run -d --name $CONTAINER_NAME --platform linux/arm64 \
+     -v ~/.aws:/root/.aws \
+     -e AWS_PROFILE=$AWS_PROFILE \
+     ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com/$FIREHOSE_REPO:latest
 
 # to stop a container
 # docker stop $CONTAINER_NAME
 # docker rm $CONTAINER_NAME
+
+# list all containers
+# docker ps
+# docker ps -a # including stopped containers
+
+# see logs for a container
+# docker logs $CONTAINER_NAME
+
+# inspect a container
+# docker inspect --format='{{.State.Status}}' sync-firehose-container
+# docker inspect sync-firehose-container

--- a/scripts/setup_new_firehose_ec2_instance.sh
+++ b/scripts/setup_new_firehose_ec2_instance.sh
@@ -10,8 +10,7 @@ chmod 400 firehoseSyncEc2Key.pem
 
 # 2. SSH into the instance
 # replace with the correct instance address
-ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-188-39-255.us-east-2.compute.amazonaws.com
-
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-222-193-178.us-east-2.compute.amazonaws.com
 # 3. Basic setup
 sudo yum update -y
 sudo yum install git -y
@@ -22,8 +21,7 @@ sudo usermod -a -G docker ec2-user
 
 # exit instance, then SSH back in
 exit
-ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-188-39-255.us-east-2.compute.amazonaws.com
-
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-222-193-178.us-east-2.compute.amazonaws.com
 # install Github CLI: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#amazon-linux-2-yum
 type -p yum-config-manager >/dev/null || sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo

--- a/scripts/setup_new_firehose_ec2_instance.sh
+++ b/scripts/setup_new_firehose_ec2_instance.sh
@@ -31,6 +31,23 @@ sudo service docker start
 # sudo service docker start
 sudo usermod -a -G docker ec2-user
 
+# Configure Docker log rotation. This is so that we don't accumulate a ton of
+# logs in the EC2 instance. We're not using a large instance, so we do need to
+# limit the amount of space we're using. The logs are stored in Cloudwatch, so
+# we don't need to worry about filling up the disk.
+sudo tee /etc/docker/daemon.json > /dev/null <<EOL
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOL
+
+# Restart Docker to apply the new configuration
+sudo systemctl restart docker
+
 # exit instance, then SSH back in
 exit
 ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-3-129-70-136.us-east-2.compute.amazonaws.com# install Github CLI: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#amazon-linux-2-yum

--- a/scripts/setup_new_firehose_ec2_instance.sh
+++ b/scripts/setup_new_firehose_ec2_instance.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# instructions for setting up a new ec2 instance for running the firehose
+# pipeline.
+
+# assumes that you have the ec2 instance already spun up.
+
+# 1. Set up login creds for SSH
+chmod 400 firehoseSyncEc2Key.pem
+
+# 2. SSH into the instance
+# replace with the correct instance address
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-188-39-255.us-east-2.compute.amazonaws.com
+
+# 3. Basic setup
+sudo yum update -y
+sudo yum install git -y
+sudo yum -y install docker
+
+sudo service docker start
+sudo usermod -a -G docker ec2-user
+
+# exit instance, then SSH back in
+exit
+ssh -i "firehoseSyncEc2Key.pem" ec2-user@ec2-18-188-39-255.us-east-2.compute.amazonaws.com
+
+# install Github CLI: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#amazon-linux-2-yum
+type -p yum-config-manager >/dev/null || sudo yum install yum-utils
+sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo yum install gh
+
+# clone repo
+git clone https://github.com/METResearchGroup/bluesky-research.git
+
+# set up AWS access
+aws configure # use the same creds as in .aws/config
+aws sso configure # use same sso creds as in .aws/config
+export AWS_PROFILE="AWSAdministratorAccess-517478598677"
+ACCOUNT_ID=$(aws sts get-caller-identity --profile $AWS_PROFILE --query "Account" --output text)
+
+# connect to ECR
+aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com
+
+# get sync firehose image from ECR
+export FIREHOSE_REPO="sync_firehose_stream_service"
+docker pull ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com/$FIREHOSE_REPO:latest
+
+# set up Cloudwatch logs for Docker container
+
+# run container
+export CONTAINER_NAME="sync-firehose-container"
+docker run -d --name $CONTAINER_NAME --platform linux/arm64 ${ACCOUNT_ID}.dkr.ecr.us-east-2.amazonaws.com/$FIREHOSE_REPO:latest
+
+# to stop a container
+# docker stop $CONTAINER_NAME
+# docker rm $CONTAINER_NAME

--- a/services/sync/stream/export_data.py
+++ b/services/sync/stream/export_data.py
@@ -52,7 +52,10 @@ from lib.constants import root_local_data_directory
 from lib.db.bluesky_models.raw import FirehoseSubscriptionStateCursorModel
 from lib.db.manage_local_data import write_jsons_to_local_store
 from lib.helper import generate_current_datetime_str
+from lib.log.logger import get_logger
 from services.participant_data.study_users import get_study_user_manager
+
+logger = get_logger(__name__)
 
 current_file_directory = os.path.dirname(os.path.abspath(__file__))
 root_write_path = os.path.join(current_file_directory, "cache")
@@ -227,7 +230,7 @@ def export_study_user_post_s3(base_path: str):
             data = json.load(f)
             s3.write_dict_json_to_s3(data=data, key=full_key)
 
-    print(f"Exported {len(posts_filenames)} post records to S3 for study user DID {key_root[1]}.")  # noqa
+    logger.info(f"Exported {len(posts_filenames)} post records to S3 for study user DID {key_root[1]}.")  # noqa
 
 
 def export_study_user_follow_s3(base_path: str):
@@ -259,7 +262,7 @@ def export_study_user_follow_s3(base_path: str):
                 s3.write_dict_json_to_s3(data=data, key=full_key)
             total_records += 1
 
-    print(f"Exported {total_records} follow records to S3 for study user DID {key_root[1]}.")  # noqa
+    logger.info(f"Exported {total_records} follow records to S3 for study user DID {key_root[1]}.")  # noqa
 
 
 def export_study_user_like_s3(base_path: str):
@@ -295,7 +298,7 @@ def export_study_user_like_s3(base_path: str):
                 s3.write_dict_json_to_s3(data=data, key=full_key)
             total_records += 1
 
-    print(f"Exported {total_records} like records to S3 for study user DID {key_root[1]}.")  # noqa
+    logger.info(f"Exported {total_records} like records to S3 for study user DID {key_root[1]}.")  # noqa
 
 
 def export_like_on_study_user_post_s3(base_path: str):
@@ -326,7 +329,7 @@ def export_like_on_study_user_post_s3(base_path: str):
                 s3.write_dict_json_to_s3(data=data, key=full_key)
             total_records += 1
 
-    print(f"Exported {total_records} like on user post records to S3 for study user DID {key_root[1]}.")  # noqa
+    logger.info(f"Exported {total_records} like on user post records to S3 for study user DID {key_root[1]}.")  # noqa
 
 
 def export_reply_to_study_user_post_s3(base_path: str):
@@ -363,7 +366,7 @@ def export_reply_to_study_user_post_s3(base_path: str):
                 s3.write_dict_json_to_s3(data=data, key=full_key)
             total_records += 1
 
-    print(f"Exported {total_records} reply to user post records to S3 for study user DID {key_root[1]}.")  # noqa
+    logger.info(f"Exported {total_records} reply to user post records to S3 for study user DID {key_root[1]}.")  # noqa
 
 
 def export_study_user_activity_local_data():
@@ -380,7 +383,7 @@ def export_study_user_activity_local_data():
     """
     study_users = os.listdir(study_user_activity_root_local_path)
     for author_did in study_users:
-        print(f"Exporting study user activity data for author DID {author_did}.")  # noqa
+        logger.info(f"Exporting study user activity data for author DID {author_did}.")  # noqa
         author_path = os.path.join(study_user_activity_root_local_path, author_did)
         for operation in ["create", "delete"]:
             if operation == "create":


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Deploy-sync-firehose-via-EC2-eaa73086db91402383437dc3f60957ee?pvs=4

After meeting with IT, it seems like having persistent compute for a long-lasting job is infeasible with Quest (it's not designed for that, it seems). Easiest solution is just to use an EC2 instance.

This PR contains a bash script that captures the steps required to set up a fresh EC2 instance to run the firehose pipeline as a Docker container.