### PR TITLE
Update firehose to sync only in-network activity

### DIFF
--- a/pipelines/get_existing_user_social_network/src/get_existing_user_social_network/helper.py
+++ b/pipelines/get_existing_user_social_network/src/get_existing_user_social_network/helper.py
@@ -81,7 +81,7 @@ def fetch_follows_for_user(user_handle: str, user_did: str):
             "follower_url": f"https://bsky.app/profile/{user_handle}",
             "follower_did": user_did,
             "insert_timestamp": current_datetime_str,
-            "relationship_to_study_user": "follow",
+            "relationship_to_study_user": "follow",  # equivalent to 'followee'
         }
         for profile in profiles
     ]

--- a/services/participant_data/study_users.py
+++ b/services/participant_data/study_users.py
@@ -78,20 +78,23 @@ class StudyUserManager:
         study_users = get_all_users()
         return set([user.bluesky_user_did for user in study_users])
 
-    def _load_in_network_user_dids(self) -> set[str]:
-        """Load the in_network_nuser_dids_set from DynamoDB."""
-        print(
-            """
-            THIS SHOULD ONLY BE CALLED AT THE BEGINNING OF THE STREAMING
-            PROCESS
-            """
-        )
-        print(
-            """
-            Since this is a singleton class, the in-network user DIDs should
-            only be loaded once at the beginning of the streaming process.
-            """
-        )
+    def _load_in_network_user_dids(self, is_refresh: bool = False) -> set[str]:
+        """Load the in_network_user_dids_set from DynamoDB."""
+        if is_refresh:
+            print("Refreshing the list of in-network user DIDs.")
+        else:
+            print(
+                """
+                THIS SHOULD ONLY BE CALLED AT THE BEGINNING OF THE STREAMING
+                PROCESS
+                """
+            )
+            print(
+                """
+                Since this is a singleton class, the in-network user DIDs should
+                only be loaded once at the beginning of the streaming process.
+                """
+            )
         query = """
         SELECT 
             CASE 

--- a/services/sync/stream/data_filter.py
+++ b/services/sync/stream/data_filter.py
@@ -3,7 +3,6 @@
 Based on https://github.com/MarshalX/bluesky-feed-generator/blob/main/server/data_filter.py
 """  # noqa
 
-import os
 from typing import Literal, Optional
 
 from atproto_client.models.app.bsky.graph.follow import Record as FollowRecord
@@ -13,10 +12,8 @@ from lib.db.bluesky_models.raw import RawFollow, RawFollowRecord, RawLike, RawLi
 from lib.db.bluesky_models.transformations import TransformedRecordWithAuthorModel  # noqa
 from lib.log.logger import get_logger
 from services.sync.stream.export_data import (
-    export_filepath_map,
     export_in_network_user_data_local,
     export_study_user_data_local,
-    write_data_to_json,
 )
 from services.consolidate_post_records.helper import consolidate_firehose_post
 from services.consolidate_post_records.models import ConsolidatedPostRecordModel  # noqa
@@ -60,9 +57,11 @@ def manage_like(like: dict, operation: Literal["create", "delete"]) -> None:
         filename = f"like_uri_suffix={uri_suffix}.json"
         like_model_dict = like
 
-    folder_path = export_filepath_map[operation]["like"]
-    full_path = os.path.join(folder_path, filename)
-    write_data_to_json(like_model_dict, full_path)
+    # NOTE: here in case we want to revisit writing all data to S3. Right now
+    # we're only writing in-network posts to S3.
+    # folder_path = export_filepath_map[operation]["like"]
+    # full_path = os.path.join(folder_path, filename)
+    # write_data_to_json(like_model_dict, full_path)
 
     # we care about the likes they create, not the ones they delete.
     # plus, deleted likes only have the URI of the original like and not
@@ -169,9 +168,11 @@ def manage_follow(follow: dict, operation: Literal["create", "delete"]) -> None:
         filename = f"follow_uri_suffix={follow_uri_suffix}.json"
         follow_model_dict = follow
 
-    folder_path = export_filepath_map[operation]["follow"]
-    full_path = os.path.join(folder_path, filename)
-    write_data_to_json(follow_model_dict, full_path)
+    # NOTE: here in case we want to revisit writing all data to S3. Right now
+    # we're only writing in-network posts to S3.
+    # folder_path = export_filepath_map[operation]["follow"]
+    # full_path = os.path.join(folder_path, filename)
+    # write_data_to_json(follow_model_dict, full_path)
 
     # we only care about the follows they create, not the ones they delete.
     # plus, deleted follows only have the URI of the original like and not
@@ -275,9 +276,12 @@ def manage_post(post: dict, operation: Literal["create", "delete"]):
         filename = f"post_uri_suffix={post_uri_suffix}.json"
         consolidated_post_dict = post
 
-    folder_path = export_filepath_map[operation]["post"]
-    full_path = os.path.join(folder_path, filename)
-    write_data_to_json(consolidated_post_dict, full_path)
+    # NOTE: here in case we want to revisit writing all data to S3. Right now
+    # we're only writing in-network posts to S3.
+
+    # folder_path = export_filepath_map[operation]["post"]
+    # full_path = os.path.join(folder_path, filename)
+    # write_data_to_json(consolidated_post_dict, full_path)
 
     if operation == "create":
         # Case 1: Check if the post was written by the study user.

--- a/services/sync/stream/export_data.py
+++ b/services/sync/stream/export_data.py
@@ -496,18 +496,19 @@ def export_in_network_user_activity_local_data():
             f"Exported {len(post_filenames)} post records for author {author_did} to S3 for in-network user activity."
         )  # noqa
     # send SQS message referencing all posts.
-    sqs.send_message(
-        source="firehose",
-        data={
-            "sync": {
-                "source": "in-network-user-activity",
-                "operation": "create",
-                "operation_type": "post",
-                "s3_keys": all_s3_keys,
-            }
-        },
-        custom_log=f"Sending message to SQS queue from firehose feed for new posts at {all_s3_keys}",  # noqa
-    )
+    if len(all_s3_keys) > 0:
+        sqs.send_message(
+            source="firehose",
+            data={
+                "sync": {
+                    "source": "in-network-user-activity",
+                    "operation": "create",
+                    "operation_type": "post",
+                    "s3_keys": all_s3_keys,
+                }
+            },
+            custom_log=f"Sending message to SQS queue from firehose feed for new posts at {all_s3_keys}",  # noqa
+        )
 
 
 def export_batch(

--- a/services/sync/stream/export_data.py
+++ b/services/sync/stream/export_data.py
@@ -184,7 +184,6 @@ def compress_cached_files_and_write_to_storage(
     operation_type: Literal["post", "like", "follow"],
     compressed: bool = True,
     external_store: Literal["local", "s3"] = "s3",
-    send_sqs_message: bool = True,
 ):
     """For a given set of files in a directory, compress them into a single
     cached file and write to S3.
@@ -526,7 +525,11 @@ def export_batch(
     Exports both the general firehose sync data and the study user activity data.
     that has been tracked in this batch.
     """  # noqa
-    export_general_firehose_sync(compressed=compressed, external_store=external_store)
+    write_all_data_to_s3 = False
+    if write_all_data_to_s3:
+        export_general_firehose_sync(
+            compressed=compressed, external_store=external_store
+        )
     export_study_user_activity_local_data()
     export_in_network_user_activity_local_data()
 


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Update-firehose-sync-code-to-only-sync-study-user-activity-and-in-network-posts-824b11256df4473ab6ca6676b3c959b0?pvs=4

We don't need to sync all posts, just those relating to study user activity.