### PR TITLE
BUG: delete old files that were written before S3 TTL lifecycle policy was in place

### DIFF
--- a/lib/aws/s3.py
+++ b/lib/aws/s3.py
@@ -34,6 +34,7 @@ class S3:
 
     def __init__(self):
         self.client = create_client("s3")
+        self.bucket = ROOT_BUCKET
 
     @retry_on_aws_rate_limit
     def list_buckets(self) -> list[str]:

--- a/services/delete_old_s3_objects/helper.py
+++ b/services/delete_old_s3_objects/helper.py
@@ -1,0 +1,40 @@
+"""Helper utility code for deleting old objects in S3 that should be TTLed.
+
+We have a lifecycle policy for this now, but the lifecycle policy doesn't
+apply retroactively, so objects created before that policy was in place
+don't have this TTL.
+
+We can use this script to delete old objects from the S3 bucket.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from lib.aws.s3 import S3
+from lib.log.logger import get_logger
+
+s3_client = S3()
+
+logger = get_logger(__name__)
+
+
+def delete_old_objects(s3_client: S3, prefix: str) -> None:
+    """Deletes S3 objects older than 24 hours from the specified prefix."""
+    keys = s3_client.list_keys_given_prefix(prefix)
+    logger.info(f"Loaded {len(keys)} objects from {prefix}")
+    total_deleted_objects = 0
+    for key in keys:
+        # Get the object's metadata to retrieve the last modified timestamp
+        response = s3_client.client.head_object(Bucket=s3_client.bucket, Key=key)
+        last_modified = response["LastModified"]
+        now = datetime.now(timezone.utc)
+        # Check if the object is older than 24 hours
+        if now - last_modified > timedelta(hours=24):
+            s3_client.delete_from_s3(key)
+            total_deleted_objects += 1
+    logger.info(f"Deleted {total_deleted_objects} old objects from {prefix}")
+
+
+if __name__ == "__main__":
+    prefixes = ["daily-posts/", "athena-results/", "sqs-messages/"]
+    for prefix in prefixes:
+        delete_old_objects(s3_client, prefix)

--- a/services/delete_old_s3_objects/helper.py
+++ b/services/delete_old_s3_objects/helper.py
@@ -22,7 +22,7 @@ def delete_old_objects(s3_client: S3, prefix: str) -> None:
     keys = s3_client.list_keys_given_prefix(prefix)
     logger.info(f"Loaded {len(keys)} objects from {prefix}")
     total_deleted_objects = 0
-    for key in keys:
+    for i, key in enumerate(keys):
         # Get the object's metadata to retrieve the last modified timestamp
         response = s3_client.client.head_object(Bucket=s3_client.bucket, Key=key)
         last_modified = response["LastModified"]
@@ -31,6 +31,10 @@ def delete_old_objects(s3_client: S3, prefix: str) -> None:
         if now - last_modified > timedelta(hours=24):
             s3_client.delete_from_s3(key)
             total_deleted_objects += 1
+        if i % 100 == 0:
+            logger.info(
+                f"Index={i}: Deleted {total_deleted_objects} old objects from {prefix}"
+            )
     logger.info(f"Deleted {total_deleted_objects} old objects from {prefix}")
 
 


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/BUG-delete-old-files-that-were-written-before-S3-TTL-lifecycle-policy-was-in-place-59b272475bce4ecaa1abaf1e8e7c3805?pvs=4