### PR TITLE
Add manual English language filtering to rank_score_feeds service.

### DIFF
--- a/Dockerfiles/rank_score_feeds.Dockerfile
+++ b/Dockerfiles/rank_score_feeds.Dockerfile
@@ -20,9 +20,25 @@ COPY services/consolidate_enrichment_integrations/models.py ./services/consolida
 COPY services/participant_data/helper.py ./services/participant_data/helper.py
 COPY services/participant_data/mock_users.py ./services/participant_data/mock_users.py
 COPY services/participant_data/models.py ./services/participant_data/models.py
+COPY services/preprocess_raw_data/classify_language/model.py ./services/preprocess_raw_data/classify_language/model.py 
+COPY services/preprocess_raw_data/classify_language/lid.176.bin ./services/preprocess_raw_data/classify_language/lid.176.bin
 COPY services/preprocess_raw_data/models.py ./services/preprocess_raw_data/models.py
 COPY services/rank_score_feeds/helper.py ./services/rank_score_feeds/helper.py
 COPY services/rank_score_feeds/models.py ./services/rank_score_feeds/models.py
+
+# install Git and build-essential
+# requires yum instead of apt-get (if building on top of lambda base image)
+# hadolint ignore=DL3008,DL3015,DL3033
+RUN yum -y update \
+    && yum groupinstall -y "Development Tools" \
+    && yum install -y git \
+    && yum clean all
+
+# install fastText from source (pip install isn't working)
+# hadolint ignore=DL3003,DL3042
+RUN git clone https://github.com/facebookresearch/fastText.git \
+    && cd fastText \
+    && pip install .
 
 # copy handler code to /app
 COPY pipelines/rank_score_feeds/__init__.py /app/__init__.py

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -322,7 +322,7 @@ resource "aws_lambda_function" "rank_score_feeds_lambda" {
   image_uri     = "${aws_ecr_repository.rank_score_feeds_service.repository_url}:latest"
   architectures = ["arm64"]
   timeout       = 480 # 480 seconds timeout, the lambda can run for 8 minutes.
-  memory_size   = 512 # 512 MB of memory
+  memory_size   = 768 # 768 MB of memory
 
   lifecycle {
     ignore_changes = [image_uri]


### PR DESCRIPTION
Bluesky's own language filtering appears to classify every post as English, and our implementation assumed that that upstream filter worked and that we'd only do manual inference for posts that didn't have a value for the "langs" attribute. We do language inference manually here. We'll just do it in the rank_score_feeds step (could've done it, and tbh should've done it, in preprocessing), but this is a quick fix.