### PR TITLE
In the firehose, track only posts from accounts followed by study users

### DIFF
--- a/services/participant_data/crawl_delete_follower_posts.py
+++ b/services/participant_data/crawl_delete_follower_posts.py
@@ -1,0 +1,10 @@
+"""Previously, we tracked follower posts in DynamoDB.
+
+We've since moved to tracking only the posts from accounts that study
+users follow, not posts that are from accounts who follow study users.
+
+This crawls through S3 in the "in-network-user-activity" folder and deletes
+all the follower posts.
+"""
+
+pass

--- a/services/participant_data/study_users.py
+++ b/services/participant_data/study_users.py
@@ -102,7 +102,7 @@ class StudyUserManager:
                 WHEN relationship_to_study_user = 'follower' THEN follower_did
             END AS did
         FROM user_social_networks
-        WHERE relationship_to_study_user IN ('follow', 'follower')
+        WHERE relationship_to_study_user IN ('follow')
         """
         df = athena.query_results_as_df(query)
         user_dids = set(df["did"].tolist())

--- a/services/preprocess_raw_data/load_data.py
+++ b/services/preprocess_raw_data/load_data.py
@@ -164,7 +164,14 @@ def load_latest_posts(post_keys: list[str]) -> list[ConsolidatedPostRecordModel]
                 # need special processing for any compressed files.
                 jsonl_data.extend(data[0])
             else:
-                jsonl_data.append(data)
+                if isinstance(data, list):
+                    # from the most-liked feed. All the posts are in a .jsonl
+                    # list file, so it'll be a list of JSONs.
+                    jsonl_data.extend(data)
+                else:
+                    # from the firehose. All the posts are in a .json file
+                    # so it'll be a dict.
+                    jsonl_data.append(data)
     transformed_jsonl_data: list[ConsolidatedPostRecordModel] = [
         ConsolidatedPostRecordModel(**post) for post in jsonl_data
     ]


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/For-in-network-firehose-activity-track-only-accounts-that-are-followed-by-study-users-and-not-ac-60d3bb43970d4c1f860d1aac031dcca1?pvs=4