### PR TITLE
Write user session logs twice in order to always have a backup

### DIFF
--- a/feed_api/user_session_queue.py
+++ b/feed_api/user_session_queue.py
@@ -48,8 +48,12 @@ def background_s3_writer():
                 f"partition_date={partition_date}",
                 filename,
             )
+            backup_key = os.path.join(
+                "backup_user_session_logs", f"partition_date={partition_date}", filename
+            )
             s3.write_dicts_jsonl_to_s3(data=logs_to_write, key=key)
+            s3.write_dicts_jsonl_to_s3(data=logs_to_write, key=backup_key)
             logger.info(
-                f"Exported {len(logs_to_write)} user session logs to S3 to key={key}"
+                f"Exported {len(logs_to_write)} user session logs to S3 to key={key} and backup key {backup_key}"
             )  # noqa
         time.sleep(time_to_flush_seconds)


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Write-user-session-logs-to-two-locations-in-order-to-always-have-a-backup-12742343c6a380b3b278e127794768ba?pvs=4