### PR TITLE
One-off logic to write study users to S3 for easier analytics with Athena

### DIFF
--- a/scripts/write_bsky_users_to_s3.py
+++ b/scripts/write_bsky_users_to_s3.py
@@ -1,0 +1,38 @@
+"""We keep the current study users in DynamoDB.
+
+It would be nice to move them to S3 (and then process with Athena).
+
+NOTE: the users will continue to be kept (and managed) in DynamoDB, but
+this lets us, for example, join users with usage data.
+"""
+
+from datetime import datetime
+
+import pandas as pd
+
+from lib.aws.s3 import S3
+from services.participant_data.helper import get_all_users
+from services.participant_data.models import UserToBlueskyProfileModel
+
+
+study_users: list[UserToBlueskyProfileModel] = get_all_users()
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+s3_key = f"exported_study_users/{timestamp}.json"
+
+s3 = S3()
+
+
+def main():
+    study_users_df = pd.DataFrame(
+        [user.dict() for user in study_users if user.is_study_user]
+    )
+    print(
+        f"Writing {len(study_users_df)} in-study users (out of {len(study_users)} total users) to {s3_key}"
+    )
+    study_user_dicts = study_users_df.to_dict(orient="records")
+    s3.write_dicts_jsonl_to_s3(data=study_user_dicts, key=s3_key)
+    print(f"Done writing {len(study_user_dicts)} study users to {s3_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2756,6 +2756,47 @@ resource "aws_glue_catalog_table" "daily_superposters" {
   }
 }
 
+resource "aws_glue_catalog_table" "exported_study_users" {
+  name          = "exported_study_users"
+  database_name = var.default_glue_database_name
+  table_type    = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://${var.s3_root_bucket_name}/exported_study_users/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name                  = "exported_study_users_json"
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+    }
+    columns {
+      name = "bluesky_handle"
+      type = "string"
+    }
+    columns {
+      name = "bluesky_user_did"
+      type = "string"
+    }
+    columns {
+      name = "condition"
+      type = "string"
+    }
+    columns {
+      name = "created_timestamp"
+      type = "string"
+    }
+    columns {
+      name = "is_study_user"
+      type = "boolean"
+    }
+    columns {
+      name = "study_user_id"
+      type = "string"
+    }
+  }
+}
+
 
 resource "aws_glue_catalog_table" "user_session_logs" {
   name          = "user_session_logs"


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Update-user-session-log-analytics-write-study-users-to-S3-Athena-12942343c6a3807d9886d616342437a8?pvs=4