### PR TITLE
Implement queue batching

### DIFF
--- a/lib/db/queue.py
+++ b/lib/db/queue.py
@@ -29,7 +29,7 @@ existing_sqlite_dbs = [
     file for file in os.listdir(root_db_path) if file.endswith(".db")
 ]
 
-DEFAULT_PRIMARY_KEY = "uri"
+DEFAULT_BATCH_SIZE = 1000
 
 
 class QueueItem(BaseModel):
@@ -75,15 +75,9 @@ class QueueItem(BaseModel):
 
 
 class Queue:
-    def __init__(
-        self,
-        queue_name: str,
-        create_new_queue: bool = False,
-        primary_key: Optional[str] = DEFAULT_PRIMARY_KEY,
-    ):
+    def __init__(self, queue_name: str, create_new_queue: bool = False):
         self.queue_name = queue_name
         self.queue_table_name = "queue"
-        self.primary_key = primary_key
         self.db_path = os.path.join(root_db_path, f"{queue_name}.db")
         if not os.path.exists(self.db_path):
             if create_new_queue:
@@ -113,22 +107,25 @@ class Queue:
             conn.execute("PRAGMA busy_timeout=30000")  # 30 second timeout
             conn.execute("PRAGMA cache_size=-64000")  # 64MB cache
             conn.execute("PRAGMA mmap_size=268435456")  # 256MB memory mapped I/O
-            conn.execute("PRAGMA page_size=4096")
+            conn.execute("PRAGMA page_size=8192")  # Double the current size
+
+            # Add compression if you're using SQLite 3.38.0 or later
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA zip_compression=true")  # Enable compression
+            except sqlite3.OperationalError:
+                # Older SQLite version, compression not available
+                pass
 
             # Create the main table with an additional column for the primary key
             conn.execute(f"""
                 CREATE TABLE {self.queue_table_name} (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     payload TEXT,
-                    payload_key TEXT UNIQUE,
+                    metadata TEXT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     status TEXT DEFAULT 'pending'
                 )
-            """)
-            # Create an index on payload_key for better performance
-            conn.execute(f"""
-                CREATE UNIQUE INDEX idx_payload_key 
-                ON {self.queue_table_name}(payload_key)
             """)
 
             # Ensure WAL mode is persisted
@@ -172,150 +169,78 @@ class Queue:
                     continue
                 raise
 
-    def _extract_primary_key(self, payload: dict) -> str:
-        """Extract the primary key value from the payload."""
-        try:
-            if isinstance(payload, str):
-                payload = json.loads(payload)
-            return str(payload[self.primary_key])
-        except (KeyError, json.JSONDecodeError) as e:
-            raise ValueError(
-                f"Could not extract primary key '{self.primary_key}' from payload: {e}"
-            )
-
-    def add_item_to_queue(self, payload: dict) -> Optional[QueueItem]:
-        """Add single item to queue, skipping if primary key already exists."""
+    def add_item_to_queue(self, payload: dict, metadata: dict = None) -> None:
+        """Add single item to queue."""
         if not payload:
             raise ValueError("Payload cannot be empty")
 
         json_payload = json.dumps(payload)
-        payload_key = self._extract_primary_key(payload)
-        queue_item = QueueItem(payload=json_payload)
+        metadata = {**metadata, "batch_size": 1, "actual_batch_size": 1}
 
         try:
             with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.execute(
+                conn.execute(
                     f"""
                     INSERT INTO {self.queue_table_name} 
-                    (payload, payload_key, created_at, status) 
+                    (payload, metadata, created_at, status) 
                     VALUES (?, ?, ?, ?)
-                    ON CONFLICT(payload_key) DO NOTHING
                     RETURNING id
                     """,
                     (
-                        queue_item.payload,
-                        payload_key,
-                        queue_item.created_at,
-                        queue_item.status,
+                        json_payload,
+                        metadata,
+                        generate_current_datetime_str(),
+                        "pending",
                     ),
                 )
-                result = cursor.fetchone()
+        except Exception as e:
+            logger.error(f"Error adding item to queue: {e}")
+            raise e
 
-                if result is None:
-                    logger.debug(
-                        f"Skipped duplicate item with {self.primary_key}: {payload_key}"
-                    )
-                    return None
-
-                queue_item.id = result[0]
-                return queue_item
-
-        except sqlite3.IntegrityError:
-            logger.debug(
-                f"Skipped duplicate item with {self.primary_key}: {payload_key}"
-            )
-            return None
-
-    def batch_add_item_to_queue(self, items: list[dict]) -> list[QueueItem]:
-        """Add multiple items to queue, processing in chunks for memory efficiency."""
-        CHUNK_SIZE = 1000
-        all_queue_items = []
-        total_chunks = len(items) // CHUNK_SIZE
-
-        # Process items in chunks
-        for i in range(0, len(items), CHUNK_SIZE):
-            if i % 50 == 0:
-                logger.info(f"Processing chunk {i // CHUNK_SIZE} of {total_chunks}")
-            chunk = items[i : i + CHUNK_SIZE]
-            chunk_items = self._batch_add_chunk(chunk)
-            all_queue_items.extend(chunk_items)
-
-        return all_queue_items
-
-    def _batch_add_chunk(self, items: list[dict]) -> list[QueueItem]:
-        """Add multiple items to queue with retry logic."""
-        if not items:
-            return []
-
-        insert_data = []
-        payload_map = {}
-
-        for item in items:
-            if not item:
-                raise ValueError("Payload cannot be empty")
-
-            json_payload = json.dumps(item)
-            payload_key = self._extract_primary_key(item)
+    def _create_batched_chunks(
+        self,
+        chunks: list[list[dict]],
+        batch_size: int,
+        metadata: dict = None,
+    ) -> list[tuple[str, str, str, str]]:
+        """Out of the chunks, create a batch of chunks that will be written to the queue."""
+        batched_chunks: list[tuple[str, str, str, str]] = []
+        for chunk in chunks:
+            payload = json.dumps(chunk)
             created_at = generate_current_datetime_str()
             status = "pending"
+            metadata = json.dumps(
+                {**metadata, "batch_size": batch_size, "actual_batch_size": len(chunk)}
+            )
+            batched_chunks.append((payload, metadata, created_at, status))
+        return batched_chunks
 
-            insert_data.append((json_payload, payload_key, created_at, status))
-            payload_map[payload_key] = (json_payload, created_at, status)
+    def batch_add_items_to_queue(
+        self,
+        items: list[dict],
+        metadata: dict = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        """Add multiple items to queue, processing in chunks for memory
+        efficiency."""
+        chunks: list[list[dict]] = [
+            items[i : i + batch_size] for i in range(0, len(items), batch_size)
+        ]
+        batched_chunks: list[tuple[str, str, str, str]] = self._create_batched_chunks(
+            chunks=chunks, batch_size=batch_size, metadata=metadata
+        )
 
-        max_retries = 3
-        retry_delay = 1.0
+        logger.info(f"Writing {len(batched_chunks)} items to DB...")
 
-        for attempt in range(max_retries):
-            try:
-                with self._get_connection() as conn:
-                    # First perform the batch insert
-                    placeholders = ",".join(["(?, ?, ?, ?)"] * len(insert_data))
-                    conn.execute(
-                        f"""
-                        INSERT OR IGNORE INTO {self.queue_table_name}
-                        (payload, payload_key, created_at, status)
-                        VALUES {placeholders}
-                        """,
-                        [val for tup in insert_data for val in tup],
-                    )
-
-                    # Then retrieve the IDs for successfully inserted items
-                    payload_keys = list(payload_map.keys())
-                    placeholders = ",".join(["?"] * len(payload_keys))
-                    cursor = conn.execute(
-                        f"""
-                        SELECT id, payload_key, created_at 
-                        FROM {self.queue_table_name}
-                        WHERE payload_key IN ({placeholders})
-                        """,
-                        payload_keys,
-                    )
-
-                    # Create QueueItems only for successfully inserted items
-                    queue_items = []
-                    for row in cursor.fetchall():
-                        id_, payload_key, db_created_at = row
-                        payload, _, status = payload_map[payload_key]
-                        queue_item = QueueItem(
-                            id=id_,
-                            payload=payload,
-                            created_at=db_created_at,
-                            status=status,
-                        )
-                        queue_items.append(queue_item)
-
-                    return queue_items
-
-            except sqlite3.OperationalError as e:
-                if "database is locked" in str(e) and attempt < max_retries - 1:
-                    logger.warning(
-                        f"Database locked, retrying in {retry_delay} seconds... "
-                        f"(attempt {attempt + 1}/{max_retries})"
-                    )
-                    time.sleep(retry_delay)
-                    retry_delay *= 2
-                    continue
-                raise
+        # write to DB
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                f"""
+                INSERT INTO {self.queue_table_name} (payload, metadata, created_at, status)
+                VALUES (?, ?, ?, ?)
+                """,
+                batched_chunks,
+            )
 
     def remove_item_from_queue(self) -> Optional[QueueItem]:
         """Remove and return the next available item from the queue.
@@ -352,9 +277,13 @@ class Queue:
             logger.info(f"Queue size after remove: {count} items")
             return item
 
-    def batch_remove_items_from_queue(self, limit: int) -> list[QueueItem]:
+    def batch_remove_items_from_queue(
+        self, limit: Optional[int] = None
+    ) -> list[QueueItem]:
         """Remove multiple items from queue."""
         items = []
+        if limit is None:
+            limit = self.get_queue_length()
         for _ in range(limit):
             item = self.remove_item_from_queue()
             if item is None:

--- a/lib/db/tests/test_queue.py
+++ b/lib/db/tests/test_queue.py
@@ -1,11 +1,22 @@
-"""Tests for queue.py."""
+"""Tests for queue.py.
+
+This test suite verifies the functionality of the Queue class which implements
+a SQLite-backed FIFO queue system. The tests cover:
+
+- Queue creation and initialization
+- Adding single and batched items
+- Removing single and batched items
+- Queue persistence and concurrent access
+- Error handling and edge cases
+- SQLite optimization settings
+"""
 
 import os
 import json
 import time
 import pytest
 from typing import Generator
-from lib.db.queue import Queue, QueueItem
+from lib.db.queue import DEFAULT_BATCH_SIZE, Queue, QueueItem
 
 
 def get_test_queue_name() -> str:
@@ -35,197 +46,104 @@ def queue() -> Generator[Queue, None, None]:
         os.remove(q.db_path)
 
 
-@pytest.fixture
-def custom_key_queue() -> Generator[Queue, None, None]:
-    """Create a test queue with custom primary key.
-
-    Yields:
-        Queue: A newly created test queue instance with custom primary key
-    """
-    queue_name = get_test_queue_name()
-    q = Queue(queue_name=queue_name, create_new_queue=True, primary_key="custom_id")
-    yield q
-    if os.path.exists(q.db_path):
-        os.remove(q.db_path)
-
-
 def test_queue_creation(queue: Queue) -> None:
     """Test queue initialization creates expected database structure.
 
-    Verifies that:
-    - Queue name is properly prefixed
+    Verifies:
+    - Queue name is properly set
     - Table name is set correctly
     - Database file is created
     - Queue starts empty
-    - Default primary key is set
-
-    Args:
-        queue: Test queue fixture
+    - WAL mode is enabled
     """
     assert queue.queue_name.startswith("test_")
     assert queue.queue_table_name == "queue"
     assert queue.db_path.endswith(".db")
     assert os.path.exists(queue.db_path)
     assert queue.get_queue_length() == 0
-    assert queue.primary_key == "uri"
 
-
-def test_custom_primary_key_creation(custom_key_queue: Queue) -> None:
-    """Test queue creation with custom primary key.
-
-    Args:
-        custom_key_queue: Test queue fixture with custom primary key
-    """
-    assert custom_key_queue.primary_key == "custom_id"
+    # Verify WAL mode
+    with queue._get_connection() as conn:
+        cursor = conn.execute("PRAGMA journal_mode")
+        assert cursor.fetchone()[0].upper() == "WAL"
 
 
 def test_add_item_to_queue(queue: Queue) -> None:
     """Test adding a single item creates proper queue entry.
 
-    Verifies that:
-    - Returns valid QueueItem
-    - Item has correct ID, payload and status
+    Verifies:
+    - Item is added successfully
     - Queue length increases
-
-    Args:
-        queue: Test queue fixture
+    - Metadata is properly stored
     """
-    test_item = {"uri": "test123", "data": "value"}
-    queue_item = queue.add_item_to_queue(test_item)
-
-    assert isinstance(queue_item, QueueItem)
-    assert queue_item.id is not None
-    assert json.loads(queue_item.payload) == test_item
-    assert queue_item.status == "pending"
+    test_item = {"test_key": "test_value"}
+    test_metadata = {"source": "test"}
+    
+    queue.add_item_to_queue(test_item, metadata=test_metadata)
     assert queue.get_queue_length() == 1
-
-
-def test_duplicate_items(queue: Queue) -> None:
-    """Test handling of duplicate items based on primary key.
-
-    Verifies that:
-    - First item is added successfully
-    - Duplicate item is skipped
-    - Queue length remains unchanged for duplicates
-
-    Args:
-        queue: Test queue fixture
-    """
-    test_item1 = {"uri": "test123", "data": "first"}
-    test_item2 = {"uri": "test123", "data": "second"}  # Same URI
-    
-    # First item should be added successfully
-    first_item = queue.add_item_to_queue(test_item1)
-    assert first_item is not None
-    assert queue.get_queue_length() == 1
-    
-    # Second item with same URI should be skipped
-    second_item = queue.add_item_to_queue(test_item2)
-    assert second_item is None  # Should return None for duplicates
-    assert queue.get_queue_length() == 1  # Length shouldn't change
-
-
-def test_custom_primary_key_deduplication(custom_key_queue: Queue) -> None:
-    """Test deduplication with custom primary key.
-
-    Verifies that:
-    - Deduplication works with custom primary keys
-    - Only first item with unique key is added
-
-    Args:
-        custom_key_queue: Test queue fixture with custom primary key
-    """
-    test_item1 = {"custom_id": "abc", "data": "first"}
-    test_item2 = {"custom_id": "abc", "data": "second"}
-    
-    first_item = custom_key_queue.add_item_to_queue(test_item1)
-    assert first_item is not None
-    
-    second_item = custom_key_queue.add_item_to_queue(test_item2)
-    assert second_item is None
-    assert custom_key_queue.get_queue_length() == 1
 
 
 def test_batch_add_items_to_queue(queue: Queue) -> None:
     """Test batch adding multiple items processes all correctly.
 
-    Verifies that:
+    Verifies:
     - All items are added successfully
-    - Each item has correct attributes
+    - Items are properly chunked based on batch size
+    - Metadata is stored for each chunk
     - Queue length reflects total items
 
     Args:
         queue: Test queue fixture
     """
-    test_items = [{"uri": f"test_{i}", "data": f"data_{i}"} for i in range(3)]
-    queue_items = queue.batch_add_items_to_queue(test_items)
-
-    assert len(queue_items) == 3
-    assert queue.get_queue_length() == 3
-
-    for i, item in enumerate(queue_items):
-        assert isinstance(item, QueueItem)
-        assert item.id is not None
-        assert json.loads(item.payload) == test_items[i]
-        assert item.status == "pending"
+    test_items = [{"key": f"value_{i}"} for i in range(5)]
+    test_metadata = {"source": "batch_test"}
+    
+    queue.batch_add_items_to_queue(
+        items=test_items,
+        metadata=test_metadata,
+        batch_size=2
+    )
+    
+    assert queue.get_queue_length() == 3  # Should create 3 chunks (2+2+1)
 
 
 def test_batch_add_items_with_duplicates(queue: Queue) -> None:
     """Test batch adding items with some duplicates.
 
     Verifies that:
-    - Only unique items are added
-    - Duplicates are skipped
-    - Queue length reflects only unique items
+    - All items are added, including duplicates
+    - Queue length reflects total number of items
 
     Args:
         queue: Test queue fixture
     """
     test_items = [
         {"uri": "test1", "data": "first"},
-        {"uri": "test2", "data": "second"},
+        {"uri": "test2", "data": "second"}, 
         {"uri": "test1", "data": "duplicate"},  # Duplicate URI
         {"uri": "test3", "data": "third"}
     ]
     
-    queue_items = queue.batch_add_items_to_queue(test_items)
-    assert len(queue_items) == 3  # Should only add unique items
-    assert queue.get_queue_length() == 3
-    
-    # Verify the payloads of added items
-    uris = {json.loads(item.payload)["uri"] for item in queue_items}
-    assert uris == {"test1", "test2", "test3"}
-
-
-def test_missing_primary_key(queue: Queue) -> None:
-    """Test handling of items missing the primary key.
-
-    Verifies that:
-    - Adding item without primary key raises ValueError
-    - Error message indicates missing primary key
-
-    Args:
-        queue: Test queue fixture
-    """
-    test_item = {"data": "value"}  # Missing 'uri' field
-    
-    with pytest.raises(ValueError) as exc_info:
-        queue.add_item_to_queue(test_item)
-    assert "Could not extract primary key" in str(exc_info.value)
-
+    queue.batch_add_items_to_queue(
+        test_items,
+        batch_size=3 # if duplicate is removed, it would be 3 items = 1 batch. If duplicate is kept, 4 items = 2 batches
+    )
+    assert queue.get_queue_length() == 2  # Should add all items including duplicates
+        
 
 def test_remove_item_from_queue(queue: Queue) -> None:
     """Test removing single item follows FIFO order and updates status.
 
-    Verifies that:
+    Verifies:
     - Item is removed successfully
     - Removed item has correct payload and processing status
     - Empty queue returns None
+    - Status transitions from 'pending' to 'processing'
 
     Args:
         queue: Test queue fixture
     """
-    test_item = {"uri": "test123", "data": "value"}
+    test_item = {"test_key": "test_value"}
     queue.add_item_to_queue(test_item)
 
     removed_item = queue.remove_item_from_queue()
@@ -240,16 +158,20 @@ def test_remove_item_from_queue(queue: Queue) -> None:
 def test_batch_remove_items_from_queue(queue: Queue) -> None:
     """Test batch removal respects limit and FIFO ordering.
 
-    Verifies that:
+    Verifies:
     - Removes correct number of items up to limit
-    - Items have processing status
-    - Remaining items can be retrieved
+    - Items maintain FIFO order
+    - All items have processing status
+    - Returns empty list when queue is empty
 
     Args:
         queue: Test queue fixture
     """
-    test_items = [{"uri": f"test_{i}", "data": f"data_{i}"} for i in range(3)]
-    queue.batch_add_items_to_queue(test_items)
+    test_items = [{"key": f"value_{i}"} for i in range(3)]
+    queue.batch_add_items_to_queue(
+        test_items,
+        batch_size=1 # to guarantee 3 rows in the queue.
+    )
 
     # Remove 2 items
     removed_items = queue.batch_remove_items_from_queue(limit=2)
@@ -259,53 +181,54 @@ def test_batch_remove_items_from_queue(queue: Queue) -> None:
         assert item.status == "processing"
 
     # One item should remain
-    assert queue.get_queue_length() == 3  # Total count includes processed items
-    remaining_items = queue.batch_remove_items_from_queue(limit=2)
+    remaining_items = queue.batch_remove_items_from_queue()
     assert len(remaining_items) == 1
 
 
 def test_queue_empty_behavior(queue: Queue) -> None:
     """Test queue operations on empty queue return expected values.
 
-    Verifies that:
+    Verifies:
     - Removing from empty queue returns None
     - Batch removing from empty queue returns empty list
+    - Queue length remains accurate
 
     Args:
         queue: Test queue fixture
     """
     assert queue.remove_item_from_queue() is None
     assert queue.batch_remove_items_from_queue(limit=1) == []
+    assert queue.get_queue_length() == 0
 
 
-def test_invalid_payload() -> None:
+def test_invalid_payload(queue: Queue) -> None:
     """Test queue validation rejects invalid payloads.
 
-    Verifies that:
-    - Empty dictionary payload raises ValueError
-    - Ensures data integrity by validating inputs
+    Verifies:
+    - Empty payload raises ValueError
+    - Non-JSON-serializable payload raises ValueError
+    - None payload raises ValueError
     """
-    queue_name = get_test_queue_name()
-    q = Queue(queue_name=queue_name, create_new_queue=True)
+    with pytest.raises(ValueError):
+        queue.add_item_to_queue({})  # Empty payload
 
     with pytest.raises(ValueError):
-        q.add_item_to_queue({})  # Empty payload
-
-    os.remove(q.db_path)
+        queue.add_item_to_queue(None)  # None payload
 
 
 def test_queue_persistence(queue: Queue) -> None:
     """Test queue data persists across different connections.
 
-    Verifies that:
+    Verifies:
     - Data added in one connection is visible in another
     - Queue state is maintained between connections
+    - WAL mode enables concurrent access
     - Items can be processed from new connection
 
     Args:
         queue: Test queue fixture
     """
-    test_item = {"uri": "test123", "data": "value"}
+    test_item = {"test_key": "test_value"}
     queue.add_item_to_queue(test_item)
 
     # Create new connection to same queue
@@ -314,3 +237,147 @@ def test_queue_persistence(queue: Queue) -> None:
 
     removed_item = new_queue.remove_item_from_queue()
     assert json.loads(removed_item.payload) == test_item
+
+
+def test_metadata_handling(queue: Queue) -> None:
+    """Test metadata is properly stored and retrieved.
+
+    Verifies:
+    - Metadata is stored with queue items
+    - Default batch metadata is added
+    - Custom metadata is preserved
+    - Metadata JSON serialization works
+
+    Args:
+        queue: Test queue fixture
+    """
+    test_item = {"test_key": "test_value"}
+    test_metadata = {"source": "test", "priority": "high"}
+    
+    queue.add_item_to_queue(test_item, metadata=test_metadata)
+    
+    # Verify metadata through direct DB query
+    with queue._get_connection() as conn:
+        cursor = conn.execute(
+            f"SELECT metadata FROM {queue.queue_table_name} LIMIT 1"
+        )
+        stored_metadata = json.loads(cursor.fetchone()[0])
+        
+        assert stored_metadata["source"] == "test"
+        assert stored_metadata["priority"] == "high"
+        assert stored_metadata["batch_size"] == 1
+        assert stored_metadata["actual_batch_size"] == 1
+
+
+def test_batch_chunking(queue: Queue) -> None:
+    """Test batch processing chunks items correctly.
+
+    Verifies:
+    - Items are split into correct chunk sizes
+    - Last chunk handles remainder properly
+    - Batch metadata is accurate for each chunk
+    - All items are stored properly
+
+    Args:
+        queue: Test queue fixture
+    """
+    test_items = [{"key": f"value_{i}"} for i in range(7)]
+    batch_size = 3
+    
+    queue.batch_add_items_to_queue(
+        items=test_items,
+        batch_size=batch_size
+    )
+    
+    # Should create 3 chunks: 3 + 3 + 1 items
+    with queue._get_connection() as conn:
+        cursor = conn.execute(
+            f"SELECT payload, metadata FROM {queue.queue_table_name} ORDER BY created_at"
+        )
+        chunks = cursor.fetchall()
+        
+        assert len(chunks) == 3
+        
+        # First chunk should have 3 items
+        first_chunk = json.loads(chunks[0][0])
+        first_metadata = json.loads(chunks[0][1])
+        assert len(first_chunk) == 3
+        assert first_metadata["batch_size"] == batch_size
+        assert first_metadata["actual_batch_size"] == 3
+        
+        # Last chunk should have 1 item
+        last_chunk = json.loads(chunks[-1][0])
+        last_metadata = json.loads(chunks[-1][1])
+        assert len(last_chunk) == 1
+        assert last_metadata["batch_size"] == batch_size
+        assert last_metadata["actual_batch_size"] == 1
+
+
+def test_batch_with_metadata(queue: Queue) -> None:
+    """Test batch processing with custom metadata.
+
+    Verifies:
+    - Custom metadata is preserved across all chunks
+    - Batch information is added to metadata
+    - Each chunk maintains correct metadata
+    - Original metadata is not modified
+
+    Args:
+        queue: Test queue fixture
+    """
+    test_items = [{"key": f"value_{i}"} for i in range(5)]
+    test_metadata = {"source": "batch_test", "priority": "low"}
+    batch_size = 2
+    
+    queue.batch_add_items_to_queue(
+        items=test_items,
+        metadata=test_metadata,
+        batch_size=batch_size
+    )
+    
+    with queue._get_connection() as conn:
+        cursor = conn.execute(
+            f"SELECT metadata FROM {queue.queue_table_name} ORDER BY created_at"
+        )
+        all_metadata = [json.loads(row[0]) for row in cursor.fetchall()]
+        
+        assert len(all_metadata) == 3  # Should be 3 chunks (2+2+1)
+        
+        for metadata in all_metadata:
+            # Original metadata preserved
+            assert metadata["source"] == "batch_test"
+            assert metadata["priority"] == "low"
+            # Batch information added
+            assert metadata["batch_size"] == batch_size
+            assert "actual_batch_size" in metadata
+
+
+def test_default_batch_size(queue: Queue) -> None:
+    """Test default batch size behavior.
+
+    Verifies:
+    - Default batch size is used when not specified
+    - Large batches are properly chunked
+    - Metadata reflects default batch size
+
+    Args:
+        queue: Test queue fixture
+    """
+    test_items = [{"key": f"value_{i}"} for i in range(DEFAULT_BATCH_SIZE + 1)]
+    
+    queue.batch_add_items_to_queue(items=test_items)
+    
+    with queue._get_connection() as conn:
+        cursor = conn.execute(
+            f"SELECT metadata FROM {queue.queue_table_name} ORDER BY created_at"
+        )
+        all_metadata = [json.loads(row[0]) for row in cursor.fetchall()]
+        
+        assert len(all_metadata) == 2  # Should split into 2 chunks
+        
+        # First chunk should use default batch size
+        assert all_metadata[0]["batch_size"] == DEFAULT_BATCH_SIZE
+        assert all_metadata[0]["actual_batch_size"] == DEFAULT_BATCH_SIZE
+        
+        # Second chunk should have the remainder
+        assert all_metadata[1]["actual_batch_size"] == 1

--- a/lib/db/tests/test_queue.py
+++ b/lib/db/tests/test_queue.py
@@ -158,7 +158,7 @@ def test_batch_add_items_to_queue(queue: Queue) -> None:
         queue: Test queue fixture
     """
     test_items = [{"uri": f"test_{i}", "data": f"data_{i}"} for i in range(3)]
-    queue_items = queue.batch_add_item_to_queue(test_items)
+    queue_items = queue.batch_add_items_to_queue(test_items)
 
     assert len(queue_items) == 3
     assert queue.get_queue_length() == 3
@@ -188,7 +188,7 @@ def test_batch_add_items_with_duplicates(queue: Queue) -> None:
         {"uri": "test3", "data": "third"}
     ]
     
-    queue_items = queue.batch_add_item_to_queue(test_items)
+    queue_items = queue.batch_add_items_to_queue(test_items)
     assert len(queue_items) == 3  # Should only add unique items
     assert queue.get_queue_length() == 3
     
@@ -249,7 +249,7 @@ def test_batch_remove_items_from_queue(queue: Queue) -> None:
         queue: Test queue fixture
     """
     test_items = [{"uri": f"test_{i}", "data": f"data_{i}"} for i in range(3)]
-    queue.batch_add_item_to_queue(test_items)
+    queue.batch_add_items_to_queue(test_items)
 
     # Remove 2 items
     removed_items = queue.batch_remove_items_from_queue(limit=2)

--- a/services/backfill/posts/main.py
+++ b/services/backfill/posts/main.py
@@ -26,7 +26,7 @@ def backfill_posts(payload: dict):
         )  # noqa
         queue = Queue(queue_name=integration, create_new_queue=True)
         payloads = [{"uri": uri} for uri in post_uris]
-        queue.batch_add_item_to_queue(payloads)
+        queue.batch_add_items_to_queue(payloads)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related Notion doc: https://www.notion.so/torresmark/Add-more-batching-to-queue-implementation-18142343c6a380ce830de5e2bc070b54?pvs=4

Adds dynamic batching to queue implementation, by dumping "BATCH_SIZE" # of records into a single JSON string that is a row in the SQLite queue DB. Removes check for duplication (leaves deduplication management and idempotency to downstream consumers). Updates queue testing accordingly. Ran locally and also in prod.

Previous implementation (naive batching, concurrent writing of single records to DB) with 1M records (=1M rows): 45 minutes.

New implementation (batch size of 1,000, single writer) with 1M records (=1M / 1,000 = 1,000 rows) = 20 seconds.
