### PR TITLE
Remove duplicate Post interface definition

### DIFF
--- a/bluesky_database/frontend/src/app/__tests__/csv-export.test.tsx
+++ b/bluesky_database/frontend/src/app/__tests__/csv-export.test.tsx
@@ -2,14 +2,6 @@ import '@testing-library/jest-dom'
 import { exportToCSV, escapeCSVField, type Post } from '@/utils/csvExport'
 
 
-// Mock data structure matching the page component
-interface Post {
-  id: string
-  timestamp: string
-  username: string
-  text: string
-}
-
 // Extract and test the CSV export function directly
 const exportToCSV = (posts: Post[]) => {
   const headers = ['Timestamp', 'Username', 'Post Preview']


### PR DESCRIPTION
Remove duplicate local `Post` interface definition to rely on the imported type.