### PR TITLE
Remove duplicate escapeCSVField definition

### DIFF
--- a/bluesky_database/frontend/src/utils/csvExport.ts
+++ b/bluesky_database/frontend/src/utils/csvExport.ts
@@ -6,18 +6,22 @@ interface Post {
 }
 
 /**
+ * Helper function to escape and quote CSV fields according to RFC 4180
+ * @param field - The field value to escape
+ * @returns The properly escaped and quoted field
+ */
+export const escapeCSVField = (field: string): string => {
+  // Always quote fields to ensure RFC 4180 compliance
+  // Escape any existing quotes by doubling them
+  const escapedField = field.replace(/"/g, '""')
+  return `"${escapedField}"`
+}
+
+/**
  * Exports an array of posts to a CSV file and triggers download
  * @param posts - Array of Post objects to export
  */
 export const exportToCSV = (posts: Post[]): void => {
-  // Helper function to properly escape and quote CSV fields according to RFC 4180
-  const escapeCSVField = (field: string): string => {
-    // Always quote fields to ensure RFC 4180 compliance
-    // Escape any existing quotes by doubling them
-    const escapedField = field.replace(/"/g, '""')
-    return `"${escapedField}"`
-  }
-
   const headers = ['Timestamp', 'Username', 'Post Preview']
   const csvContent = [
     headers.map(escapeCSVField).join(','),
@@ -45,18 +49,6 @@ export const exportToCSV = (posts: Post[]): void => {
     link.click()
     document.body.removeChild(link)
   }
-}
-
-/**
- * Helper function to escape and quote CSV fields according to RFC 4180
- * @param field - The field value to escape
- * @returns The properly escaped and quoted field
- */
-export const escapeCSVField = (field: string): string => {
-  // Always quote fields to ensure RFC 4180 compliance
-  // Escape any existing quotes by doubling them
-  const escapedField = field.replace(/"/g, '""')
-  return `"${escapedField}"`
 }
 
 export type { Post }


### PR DESCRIPTION
Eliminate duplication of `escapeCSVField` function to adhere to the DRY principle.