### PR TITLE
In-Network vs Out-of-Network Feed Label Comparison Analysis

### DIFF
--- a/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/README.md
+++ b/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/README.md
@@ -1,0 +1,160 @@
+# In-Network vs Out-of-Network Feed Label Comparison Analysis
+
+**Analysis Date**: September 2, 2025  
+**Analysis Type**: Content Label Comparison Between Network Types
+
+## Purpose
+
+This analysis compares the content characteristics (labels) of posts that are in-network versus out-of-network for each user in the study. It examines whether there are systematic differences in content quality, toxicity, political orientation, and other characteristics between posts from users' social networks versus external sources.
+
+## What This Analysis Does
+
+### **Core Functionality**
+The analysis examines content differences by:
+
+1. **Network Type Filtering**: Separates posts into two categories:
+   - **In-Network Posts**: Posts from users' social connections (friends, follows)
+   - **Out-of-Network Posts**: Posts from users outside the social network
+
+2. **Content Label Analysis**: Analyzes the content characteristics using multiple ML classifiers:
+   - **Perspective API**: Toxic vs. constructive content
+   - **Sociopolitical**: Political ideology (left, moderate, right, unclear) and political vs. non-political
+   - **IME (Intergroup, Moral, Emotion)**: Content categorization by social dynamics
+   - **Valence Classifier**: Emotional tone (positive, negative, neutral)
+
+3. **Time Aggregation**: Provides both daily and weekly aggregated metrics per user
+
+### **Usage**
+
+The analysis is run with a command line flag to specify which network type to analyze:
+
+```bash
+# Analyze in-network posts
+python main.py --network_type in_network
+
+# Analyze out-of-network posts  
+python main.py --network_type out_of_network
+```
+
+### **Data Flow**
+
+```
+Generated Feeds → Parse JSON → Filter by is_in_network flag → Extract Post URIs → 
+Load Labels → Calculate Metrics → Daily/Weekly Aggregation → CSV Export
+```
+
+## Output Files
+
+### **Data Files**
+
+The analysis generates timestamped CSV files in a `results/{timestamp}/` directory:
+
+- **Daily Results**: `daily_{network_type}_feed_content_analysis_{timestamp}.csv`
+- **Weekly Results**: `weekly_{network_type}_feed_content_analysis_{timestamp}.csv`
+
+### **Visualization Files**
+
+The visualization script generates comparison plots:
+
+- **Daily Visualizations**: `daily_{label}_in_network_vs_out_of_network.png`
+- **Weekly Visualizations**: `weekly_{label}_in_network_vs_out_of_network.png`
+
+Each plot shows:
+- Time series comparing in-network vs out-of-network for a specific content label
+- Separate lines for each study condition (engagement, representative_diversification, reverse_chronological)
+- Solid lines for in-network, dashed lines for out-of-network
+- Color coding by condition (red=engagement, green=representative_diversification, black=reverse_chronological)
+
+## Key Metrics Generated
+
+### **Per-User, Per-Day Metrics:**
+- Average toxicity scores for in-network vs out-of-network posts
+- Proportion of constructive content in each network type
+- Political orientation distributions
+- Emotional valence patterns
+- IME categorization differences
+
+### **Per-User, Per-Week Metrics:**
+- Weekly aggregated versions of all daily metrics
+- Smoothed trends over time
+
+## Expected Insights
+
+This analysis can reveal:
+
+1. **Echo Chamber Effects**: Whether in-network content is more homogeneous
+2. **Content Quality Differences**: If one network type has higher/lower quality content
+3. **Political Polarization**: Whether in-network content is more politically aligned
+4. **Toxicity Patterns**: If toxicity levels differ between network types
+5. **Temporal Trends**: How these differences change over the study period
+
+## File Structure
+
+```
+in_network_out_of_network_feed_label_comparison_2025_09_02/
+├── main.py                           # Main analysis script
+├── visualize_results.py              # Visualization script
+├── submit_in_network_analysis.sh     # Slurm script for in-network analysis
+├── submit_out_of_network_analysis.sh # Slurm script for out-of-network analysis
+├── README.md                         # This documentation
+└── results/                          # Output directory
+    └── {timestamp}/                  # Timestamped results
+        ├── daily_in_network_feed_content_analysis_{timestamp}.csv
+        ├── weekly_in_network_feed_content_analysis_{timestamp}.csv
+        ├── daily_out_of_network_feed_content_analysis_{timestamp}.csv
+        ├── weekly_out_of_network_feed_content_analysis_{timestamp}.csv
+        └── *.png                     # Visualization files
+```
+
+## Dependencies
+
+- pandas
+- matplotlib
+- numpy
+- Standard project libraries (lib.helper, lib.log, services.calculate_analytics.shared.*)
+
+## Running the Analysis
+
+### **Using Slurm Scripts (Recommended)**
+
+The analysis should be run using the provided Slurm scripts on the cluster:
+
+1. **Submit In-Network Analysis**:
+   ```bash
+   cd services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02
+   sbatch submit_in_network_analysis.sh
+   ```
+
+2. **Submit Out-of-Network Analysis**:
+   ```bash
+   sbatch submit_out_of_network_analysis.sh
+   ```
+
+3. **Generate Visualizations** (after both analyses complete):
+   ```bash
+   python visualize_results.py
+   ```
+
+**Important**: You must run both Slurm scripts (in-network and out-of-network) before running the visualization script, as it needs both datasets to create comparison plots.
+
+### **Manual Execution (Alternative)**
+
+If running locally without Slurm:
+
+1. **Run In-Network Analysis**:
+   ```bash
+   cd services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02
+   python main.py --network_type in_network
+   ```
+
+2. **Run Out-of-Network Analysis**:
+   ```bash
+   python main.py --network_type out_of_network
+   ```
+
+3. **Generate Visualizations**:
+   ```bash
+   python visualize_results.py
+   ```
+
+The visualization script will automatically find the most recent analysis results and create comparison plots.

--- a/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/main.py
+++ b/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/main.py
@@ -1,0 +1,328 @@
+"""Compare content labels between in-network and out-of-network posts used in feeds.
+
+This analysis compares the content characteristics (labels) of posts that are
+in-network versus out-of-network for each user, per day and per week.
+
+Usage:
+    python main.py --network_type in_network
+    python main.py --network_type out_of_network
+"""
+
+import argparse
+import os
+from datetime import datetime
+
+import pandas as pd
+
+from lib.constants import timestamp_format
+from lib.helper import generate_current_datetime_str, get_partition_dates
+from lib.log.logger import get_logger
+from services.calculate_analytics.shared.constants import (
+    STUDY_START_DATE,
+    STUDY_END_DATE,
+    exclude_partition_dates,
+)
+from services.calculate_analytics.shared.analysis.content_analysis import (
+    get_daily_feed_content_per_user_metrics,
+    get_weekly_content_per_user_metrics,
+    transform_daily_content_per_user_metrics,
+    transform_weekly_content_per_user_metrics,
+)
+from services.calculate_analytics.shared.data_loading.feeds import get_feeds_per_user
+from services.calculate_analytics.shared.data_loading.labels import (
+    get_all_labels_for_posts,
+)
+from services.calculate_analytics.shared.data_loading.users import load_user_data
+from services.fetch_posts_used_in_feeds.helper import load_feed_from_json_str
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+current_datetime_str: str = generate_current_datetime_str()
+
+logger = get_logger(__file__)
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare content labels between in-network and out-of-network posts"
+    )
+    parser.add_argument(
+        "--network_type",
+        type=str,
+        required=True,
+        choices=["in_network", "out_of_network"],
+        help="Type of network posts to analyze: 'in_network' or 'out_of_network'",
+    )
+    return parser.parse_args()
+
+
+def get_network_filtered_post_uris_per_user_per_day(
+    valid_study_users_dids: set[str], network_type: str
+) -> dict[str, dict[str, set[str]]]:
+    """Get post URIs used in feeds filtered by network type (in-network or out-of-network).
+
+    Args:
+        valid_study_users_dids: Set of valid study user DIDs
+        network_type: Either "in_network" or "out_of_network"
+
+    Returns:
+        Dictionary mapping user DIDs to dates to sets of post URIs
+    """
+    generated_feeds_df: pd.DataFrame = get_feeds_per_user(valid_study_users_dids)
+
+    feeds_per_user: dict[str, dict[str, set[str]]] = {}
+    is_in_network_filter = network_type == "in_network"
+
+    # Collect URIs filtered by network type
+    for row in generated_feeds_df.itertuples():
+        user_did = row.bluesky_user_did
+        timestamp = row.feed_generation_timestamp
+        feed_generation_date = datetime.strptime(timestamp, timestamp_format).strftime(
+            "%Y-%m-%d"
+        )
+
+        # Load the feed and extract post URIs based on network type
+        feed_json = row.feed
+        feed = load_feed_from_json_str(feed_json)
+
+        if not isinstance(feed, list):
+            logger.error(f"Feed data for user {user_did} is not a list: {type(feed)}")
+            raise ValueError(f"Invalid feed structure for user {user_did}")
+
+        # Filter posts by network type
+        filtered_post_uris = []
+        for post in feed:
+            is_in_network = post.get("is_in_network", False)
+            if is_in_network == is_in_network_filter:
+                filtered_post_uris.append(post["item"])
+
+        # Add to the structure
+        if user_did not in feeds_per_user:
+            feeds_per_user[user_did] = {}
+
+        if feed_generation_date not in feeds_per_user[user_did]:
+            feeds_per_user[user_did][feed_generation_date] = set()
+
+        feeds_per_user[user_did][feed_generation_date].update(filtered_post_uris)
+
+    logger.info(f"Filtered {network_type} posts for {len(feeds_per_user)} users")
+    return feeds_per_user
+
+
+def do_setup(network_type: str):
+    """Setup steps for analysis."""
+
+    # Load users and partition dates
+    try:
+        user_df, user_date_to_week_df, valid_study_users_dids = load_user_data()
+        partition_dates: list[str] = get_partition_dates(
+            start_date=STUDY_START_DATE,
+            end_date=STUDY_END_DATE,
+            exclude_partition_dates=exclude_partition_dates,
+        )
+    except Exception as e:
+        logger.error(f"Failed to load user data and/or partition dates: {e}")
+        raise
+
+    # Load feeds filtered by network type
+    try:
+        user_to_content_in_feeds: dict[str, dict[str, set[str]]] = (
+            get_network_filtered_post_uris_per_user_per_day(
+                valid_study_users_dids=valid_study_users_dids, network_type=network_type
+            )
+        )
+    except Exception as e:
+        logger.error(f"Failed to get {network_type} feeds per user: {e}")
+        raise
+
+    # Load labels for feed content
+    try:
+        from services.calculate_analytics.shared.data_loading.feeds import (
+            get_all_post_uris_used_in_feeds,
+        )
+
+        feed_content_uris: set[str] = get_all_post_uris_used_in_feeds(
+            user_to_content_in_feeds=user_to_content_in_feeds
+        )
+        labels_for_feed_content: dict[str, dict] = get_all_labels_for_posts(
+            post_uris=feed_content_uris, partition_dates=partition_dates
+        )
+    except Exception as e:
+        logger.error(f"Failed to get labels for {network_type} feed content: {e}")
+        raise
+
+    return {
+        "user_df": user_df,
+        "user_date_to_week_df": user_date_to_week_df,
+        "valid_study_users_dids": valid_study_users_dids,
+        "user_to_content_in_feeds": user_to_content_in_feeds,
+        "labels_for_feed_content": labels_for_feed_content,
+        "partition_dates": partition_dates,
+    }
+
+
+def do_analysis_and_export_results(
+    user_df: pd.DataFrame,
+    user_date_to_week_df: pd.DataFrame,
+    user_to_content_in_feeds: dict[str, dict[str, set[str]]],
+    labels_for_feed_content: dict[str, dict],
+    partition_dates: list[str],
+    network_type: str,
+):
+    """Perform analysis and export results."""
+
+    # Create timestamped output directory
+    timestamp = generate_current_datetime_str()
+    output_dir = os.path.join(current_dir, "results", timestamp)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Define output file paths
+    daily_results_export_fp = os.path.join(
+        output_dir,
+        f"daily_{network_type}_feed_content_analysis_{timestamp}.csv",
+    )
+    weekly_results_export_fp = os.path.join(
+        output_dir,
+        f"weekly_{network_type}_feed_content_analysis_{timestamp}.csv",
+    )
+
+    # (1) Daily aggregations
+    logger.info(
+        f"[Daily analysis] Getting per-user, per-day {network_type} content label metrics..."
+    )
+
+    try:
+        user_per_day_content_label_metrics: dict[
+            str, dict[str, dict[str, float | None]]
+        ] = get_daily_feed_content_per_user_metrics(
+            user_to_content_in_feeds=user_to_content_in_feeds,
+            labels_for_feed_content=labels_for_feed_content,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to get daily {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    try:
+        transformed_per_user_per_day_content_label_metrics: pd.DataFrame = (
+            transform_daily_content_per_user_metrics(
+                user_per_day_content_label_metrics=user_per_day_content_label_metrics,
+                users=user_df,
+                partition_dates=partition_dates,
+            )
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to transform daily {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    try:
+        logger.info(
+            f"[Daily analysis] Exporting per-user, per-day {network_type} content label metrics to {daily_results_export_fp}..."
+        )
+        transformed_per_user_per_day_content_label_metrics.to_csv(
+            daily_results_export_fp, index=False
+        )
+        logger.info(
+            f"[Daily analysis] Exported per-user, per-day {network_type} content label metrics to {daily_results_export_fp}..."
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to export daily {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    # (2) Weekly aggregations
+    logger.info(
+        f"[Weekly analysis] Getting per-user, per-week {network_type} content label metrics..."
+    )
+
+    try:
+        user_per_week_content_label_metrics: dict[
+            str, dict[str, dict[str, float | None]]
+        ] = get_weekly_content_per_user_metrics(
+            user_per_day_content_label_metrics=user_per_day_content_label_metrics,
+            user_date_to_week_df=user_date_to_week_df,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to get weekly {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    try:
+        transformed_per_user_per_week_feed_content_metrics: pd.DataFrame = (
+            transform_weekly_content_per_user_metrics(
+                user_per_week_content_label_metrics=user_per_week_content_label_metrics,
+                users=user_df,
+                user_date_to_week_df=user_date_to_week_df,
+            )
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to transform weekly {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    try:
+        logger.info(
+            f"[Weekly analysis] Exporting per-user, per-week {network_type} content label metrics to {weekly_results_export_fp}..."
+        )
+        transformed_per_user_per_week_feed_content_metrics.to_csv(
+            weekly_results_export_fp, index=False
+        )
+        logger.info(
+            f"[Weekly analysis] Exported per-user, per-week {network_type} content label metrics to {weekly_results_export_fp}..."
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to export weekly {network_type} feed content per user metrics: {e}"
+        )
+        raise
+
+    logger.info(
+        f"Analysis complete for {network_type} posts. Results saved in: {output_dir}"
+    )
+
+
+def main():
+    """Execute the analysis comparing in-network vs out-of-network feed content labels."""
+    args = parse_arguments()
+    network_type = args.network_type
+
+    logger.info(f"Starting {network_type} feed content analysis")
+
+    try:
+        setup_objs = do_setup(network_type)
+
+        user_df: pd.DataFrame = setup_objs["user_df"]
+        user_date_to_week_df: pd.DataFrame = setup_objs["user_date_to_week_df"]
+        user_to_content_in_feeds: dict[str, dict[str, set[str]]] = setup_objs[
+            "user_to_content_in_feeds"
+        ]
+        labels_for_feed_content: dict[str, dict] = setup_objs["labels_for_feed_content"]
+        partition_dates: list[str] = setup_objs["partition_dates"]
+    except Exception as e:
+        logger.error(f"Failed to setup: {e}")
+        raise
+
+    try:
+        do_analysis_and_export_results(
+            user_df=user_df,
+            user_date_to_week_df=user_date_to_week_df,
+            user_to_content_in_feeds=user_to_content_in_feeds,
+            labels_for_feed_content=labels_for_feed_content,
+            partition_dates=partition_dates,
+            network_type=network_type,
+        )
+    except Exception as e:
+        logger.error(f"Failed to do analysis and export results: {e}")
+        raise
+
+    logger.info(f"{network_type} feed content analysis completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/submit_in_network_analysis.sh
+++ b/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/submit_in_network_analysis.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#SBATCH -A p32375
+#SBATCH -p short
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH -t 2:00:00
+#SBATCH --mem=25G
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-user=markptorres1@gmail.com
+#SBATCH --job-name=in_network_feed_analysis_%j
+#SBATCH --output=/projects/p32375/bluesky-research/lib/log/study_analytics/in_network_feed_analysis-%j.log
+
+# load conda env
+CONDA_PATH="/hpc/software/mamba/23.1.0/etc/profile.d/conda.sh"
+
+# set pythonpath
+PYTHONPATH="/projects/p32375/bluesky-research/:$PYTHONPATH"
+
+# Build python command
+PYTHON_CMD="/projects/p32375/bluesky-research/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/main.py"
+
+echo "Running python command: $PYTHON_CMD --network_type in_network"
+
+# Run the in-network feed analysis
+source $CONDA_PATH && conda activate bluesky_research && export PYTHONPATH=$PYTHONPATH
+echo "Starting slurm job for in-network feed analysis"
+python $PYTHON_CMD --network_type in_network
+exit_code=$?
+echo "Python script exited with code $exit_code"
+if [ $exit_code -ne 0 ]; then
+    echo "Job failed with exit code $exit_code"
+    exit $exit_code
+fi
+echo "Completed slurm job for in-network analysis."
+exit 0

--- a/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/submit_out_of_network_analysis.sh
+++ b/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/submit_out_of_network_analysis.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#SBATCH -A p32375
+#SBATCH -p short
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH -t 2:00:00
+#SBATCH --mem=25G
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-user=markptorres1@gmail.com
+#SBATCH --job-name=out_of_network_feed_analysis_%j
+#SBATCH --output=/projects/p32375/bluesky-research/lib/log/study_analytics/out_of_network_feed_analysis-%j.log
+
+# load conda env
+CONDA_PATH="/hpc/software/mamba/23.1.0/etc/profile.d/conda.sh"
+
+# set pythonpath
+PYTHONPATH="/projects/p32375/bluesky-research/:$PYTHONPATH"
+
+# Build python command
+PYTHON_CMD="/projects/p32375/bluesky-research/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/main.py"
+
+echo "Running python command: $PYTHON_CMD --network_type out_of_network"
+
+# Run the out-of-network feed analysis
+source $CONDA_PATH && conda activate bluesky_research && export PYTHONPATH=$PYTHONPATH
+echo "Starting slurm job for out-of-network feed analysis"
+python $PYTHON_CMD --network_type out_of_network
+exit_code=$?
+echo "Python script exited with code $exit_code"
+if [ $exit_code -ne 0 ]; then
+    echo "Job failed with exit code $exit_code"
+    exit $exit_code
+fi
+echo "Completed slurm job for out-of-network analysis."
+exit 0

--- a/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/visualize_results.py
+++ b/services/calculate_analytics/analyses/in_network_out_of_network_feed_label_comparison_2025_09_02/visualize_results.py
@@ -1,0 +1,419 @@
+"""
+Visualization for In-Network vs Out-of-Network Feed Label Comparison
+
+This script generates time series visualizations comparing content labels between
+in-network and out-of-network posts used in feeds. It creates overlay plots
+showing the differences in content characteristics between the two network types.
+
+The visualization shows:
+- Daily time series comparing in-network vs out-of-network for each label
+- Weekly time series comparing in-network vs out-of-network for each label
+- Separate plots for each content label (toxicity, constructive, political, etc.)
+- Overlay visualization with distinct colors for each network type
+
+Output files:
+- Multiple PNG files, one for each label and time aggregation (daily/weekly)
+- Files named like: daily_toxic_in_network_vs_out_of_network.png
+"""
+
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import glob
+from typing import Optional, List, Tuple
+from lib.log.logger import get_logger
+from lib.helper import generate_current_datetime_str
+
+logger = get_logger(__name__)
+
+# Base output directory
+current_dir = os.path.dirname(os.path.abspath(__file__))
+BASE_OUTPUT_DIR = os.path.join(current_dir, "results")
+
+# Expected file patterns
+IN_NETWORK_DAILY_PATTERN = "daily_in_network_feed_content_analysis_*.csv"
+IN_NETWORK_WEEKLY_PATTERN = "weekly_in_network_feed_content_analysis_*.csv"
+OUT_NETWORK_DAILY_PATTERN = "daily_out_of_network_feed_content_analysis_*.csv"
+OUT_NETWORK_WEEKLY_PATTERN = "weekly_out_of_network_feed_content_analysis_*.csv"
+
+# Define colors for network types
+NETWORK_COLORS = {
+    "in_network": "blue",
+    "out_of_network": "red",
+}
+
+# Define colors for conditions (from existing visualization)
+CONDITION_COLORS = {
+    "engagement": "red",
+    "representative_diversification": "green",
+    "reverse_chronological": "black",
+}
+
+
+def create_timestamped_output_dir(timestamp: str) -> str:
+    """
+    Create a timestamped output directory for this visualization run.
+
+    Args:
+        timestamp: Timestamp string for the directory name
+
+    Returns:
+        Path to the created output directory
+    """
+    # Clean timestamp for directory name (replace colons with dashes)
+    clean_timestamp = timestamp.replace(":", "-")
+    output_dir = os.path.join(BASE_OUTPUT_DIR, clean_timestamp)
+
+    os.makedirs(output_dir, exist_ok=True)
+    logger.info(f"Created visualization output directory: {output_dir}")
+
+    return output_dir
+
+
+def find_latest_files_by_pattern(pattern: str, base_dir: str) -> List[str]:
+    """
+    Find all files matching the pattern in the base directory, sorted by modification time.
+
+    Args:
+        pattern: File pattern to match (e.g., "daily_*.csv")
+        base_dir: Base directory to search in
+
+    Returns:
+        List of paths to matching files, sorted by modification time (newest first)
+    """
+    # Search for files matching the pattern
+    search_pattern = os.path.join(base_dir, "**", pattern)
+    matching_files = glob.glob(search_pattern, recursive=True)
+
+    if not matching_files:
+        logger.warning(f"No files found matching pattern: {search_pattern}")
+        return []
+
+    # Sort by modification time and return (newest first)
+    matching_files.sort(key=os.path.getmtime, reverse=True)
+    logger.info(f"Found {len(matching_files)} files matching pattern: {pattern}")
+    return matching_files
+
+
+def load_data(file_path: str) -> Optional[pd.DataFrame]:
+    """
+    Load CSV data and validate it exists.
+
+    Args:
+        file_path: Path to the CSV file
+
+    Returns:
+        DataFrame if successful, None otherwise
+    """
+    if not os.path.exists(file_path):
+        logger.error(f"File not found: {file_path}")
+        return None
+
+    try:
+        df = pd.read_csv(file_path)
+        logger.info(f"Loaded {len(df)} rows from {os.path.basename(file_path)}")
+        return df
+    except Exception as e:
+        logger.error(f"Error loading {file_path}: {e}")
+        return None
+
+
+def get_label_columns(df: pd.DataFrame) -> List[str]:
+    """
+    Extract label columns from the dataframe, excluding metadata columns.
+
+    Args:
+        df: DataFrame with the data
+
+    Returns:
+        List of label column names
+    """
+    # Exclude metadata columns
+    metadata_columns = {"bluesky_user_did", "condition", "date", "week", "user_handle"}
+
+    # Get all columns that are not metadata
+    label_columns = [col for col in df.columns if col not in metadata_columns]
+
+    logger.info(f"Found {len(label_columns)} label columns: {label_columns[:5]}...")
+    return label_columns
+
+
+def prepare_data_for_plotting(
+    in_network_df: pd.DataFrame,
+    out_network_df: pd.DataFrame,
+    time_col: str,
+    label_col: str,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Prepare data for time series plotting by aggregating by condition and time.
+
+    Args:
+        in_network_df: DataFrame with in-network data
+        out_network_df: DataFrame with out-of-network data
+        time_col: Name of the time column ('date' or 'week')
+        label_col: Name of the label column to analyze
+
+    Returns:
+        Tuple of (in_network_agg_data, out_network_agg_data)
+    """
+    # Convert time column to datetime if it's 'date'
+    if time_col == "date":
+        in_network_df[time_col] = pd.to_datetime(in_network_df[time_col])
+        out_network_df[time_col] = pd.to_datetime(out_network_df[time_col])
+
+    # Group by condition and time, calculate mean and std for in-network
+    in_network_agg = (
+        in_network_df.groupby(["condition", time_col])[label_col]
+        .agg(["mean", "std", "count"])
+        .reset_index()
+    )
+    in_network_agg["std"] = in_network_agg["std"].fillna(0)
+    in_network_agg["network_type"] = "in_network"
+
+    # Group by condition and time, calculate mean and std for out-of-network
+    out_network_agg = (
+        out_network_df.groupby(["condition", time_col])[label_col]
+        .agg(["mean", "std", "count"])
+        .reset_index()
+    )
+    out_network_agg["std"] = out_network_agg["std"].fillna(0)
+    out_network_agg["network_type"] = "out_of_network"
+
+    return in_network_agg, out_network_agg
+
+
+def create_comparison_plot(
+    in_network_agg: pd.DataFrame,
+    out_network_agg: pd.DataFrame,
+    time_col: str,
+    label_col: str,
+    output_path: str,
+    title: str,
+    ylabel: str,
+):
+    """
+    Create a comparison plot showing in-network vs out-of-network for a specific label.
+
+    Args:
+        in_network_agg: Aggregated in-network data
+        out_network_agg: Aggregated out-of-network data
+        time_col: Name of the time column
+        label_col: Name of the label column
+        output_path: Path to save the plot
+        title: Title for the plot
+        ylabel: Y-axis label
+    """
+    plt.figure(figsize=(14, 8))
+
+    # Get unique conditions
+    conditions = set(in_network_agg["condition"].unique()) | set(
+        out_network_agg["condition"].unique()
+    )
+
+    # Create the main plot
+    for condition in conditions:
+        # Plot in-network data
+        in_condition_data = in_network_agg[
+            in_network_agg["condition"] == condition
+        ].sort_values(time_col)
+        if len(in_condition_data) > 0:
+            plt.plot(
+                in_condition_data[time_col],
+                in_condition_data["mean"],
+                color=CONDITION_COLORS.get(condition, "blue"),
+                linewidth=2.5,
+                label=f"{condition} (In-Network)",
+                marker="o",
+                markersize=4,
+                linestyle="-",
+            )
+
+        # Plot out-of-network data
+        out_condition_data = out_network_agg[
+            out_network_agg["condition"] == condition
+        ].sort_values(time_col)
+        if len(out_condition_data) > 0:
+            plt.plot(
+                out_condition_data[time_col],
+                out_condition_data["mean"],
+                color=CONDITION_COLORS.get(condition, "blue"),
+                linewidth=2.5,
+                label=f"{condition} (Out-of-Network)",
+                marker="s",
+                markersize=4,
+                linestyle="--",
+            )
+
+    # Customize the plot
+    plt.title(title, fontsize=16, fontweight="bold", pad=20)
+    plt.xlabel("Date" if time_col == "date" else "Week", fontsize=12)
+    plt.ylabel(ylabel, fontsize=12)
+    plt.legend(fontsize=10, loc="upper right")
+    plt.grid(True, alpha=0.3)
+
+    # Format x-axis
+    if time_col == "date":
+        plt.xticks(rotation=45)
+        # Set x-axis limits to show full range
+        all_dates = list(in_network_agg[time_col]) + list(out_network_agg[time_col])
+        if all_dates:
+            plt.xlim(min(all_dates), max(all_dates))
+
+    # Set y-axis limits based on data range
+    all_values = list(in_network_agg["mean"]) + list(out_network_agg["mean"])
+    if all_values:
+        min_val = min(all_values)
+        max_val = max(all_values)
+        # Add some padding
+        padding = (max_val - min_val) * 0.1
+        plt.ylim(max(0, min_val - padding), min(1, max_val + padding))
+
+    plt.tight_layout()
+
+    # Save the plot
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    plt.savefig(output_path, dpi=300, bbox_inches="tight")
+    plt.close()
+
+    logger.info(f"Comparison plot saved to {output_path}")
+
+
+def create_visualizations():
+    """
+    Create all visualizations comparing in-network vs out-of-network feed content.
+    """
+    logger.info("Starting in-network vs out-of-network feed content visualization")
+
+    timestamp = generate_current_datetime_str()
+    output_dir = create_timestamped_output_dir(timestamp)
+
+    # Find the latest data files
+    in_network_daily_files = find_latest_files_by_pattern(
+        IN_NETWORK_DAILY_PATTERN, BASE_OUTPUT_DIR
+    )
+    in_network_weekly_files = find_latest_files_by_pattern(
+        IN_NETWORK_WEEKLY_PATTERN, BASE_OUTPUT_DIR
+    )
+    out_network_daily_files = find_latest_files_by_pattern(
+        OUT_NETWORK_DAILY_PATTERN, BASE_OUTPUT_DIR
+    )
+    out_network_weekly_files = find_latest_files_by_pattern(
+        OUT_NETWORK_WEEKLY_PATTERN, BASE_OUTPUT_DIR
+    )
+
+    if not (
+        in_network_daily_files
+        or in_network_weekly_files
+        or out_network_daily_files
+        or out_network_weekly_files
+    ):
+        logger.error("No data files found for visualization")
+        return
+
+    # Process daily data
+    if in_network_daily_files and out_network_daily_files:
+        logger.info("Processing daily data...")
+
+        # Load the most recent files
+        in_network_daily_df = load_data(in_network_daily_files[0])
+        out_network_daily_df = load_data(out_network_daily_files[0])
+
+        if in_network_daily_df is not None and out_network_daily_df is not None:
+            # Get label columns (should be the same for both)
+            label_columns = get_label_columns(in_network_daily_df)
+
+            # Create visualizations for each label
+            for label_col in label_columns:
+                logger.info(f"Creating daily visualization for {label_col}...")
+
+                # Prepare data for plotting
+                in_network_agg, out_network_agg = prepare_data_for_plotting(
+                    in_network_daily_df, out_network_daily_df, "date", label_col
+                )
+
+                # Create visualization
+                output_path = os.path.join(
+                    output_dir, f"daily_{label_col}_in_network_vs_out_of_network.png"
+                )
+                title = f"Daily {label_col.replace('_', ' ').title()} - In-Network vs Out-of-Network"
+                ylabel = f"Average {label_col.replace('_', ' ').title()}"
+
+                create_comparison_plot(
+                    in_network_agg,
+                    out_network_agg,
+                    "date",
+                    label_col,
+                    output_path,
+                    title,
+                    ylabel,
+                )
+        else:
+            logger.error("Failed to load daily data")
+
+    # Process weekly data
+    if in_network_weekly_files and out_network_weekly_files:
+        logger.info("Processing weekly data...")
+
+        # Load the most recent files
+        in_network_weekly_df = load_data(in_network_weekly_files[0])
+        out_network_weekly_df = load_data(out_network_weekly_files[0])
+
+        if in_network_weekly_df is not None and out_network_weekly_df is not None:
+            # Get label columns (should be the same for both)
+            label_columns = get_label_columns(in_network_weekly_df)
+
+            # Create visualizations for each label
+            for label_col in label_columns:
+                logger.info(f"Creating weekly visualization for {label_col}...")
+
+                # Prepare data for plotting
+                in_network_agg, out_network_agg = prepare_data_for_plotting(
+                    in_network_weekly_df, out_network_weekly_df, "week", label_col
+                )
+
+                # Create visualization
+                output_path = os.path.join(
+                    output_dir, f"weekly_{label_col}_in_network_vs_out_of_network.png"
+                )
+                title = f"Weekly {label_col.replace('_', ' ').title()} - In-Network vs Out-of-Network"
+                ylabel = f"Average {label_col.replace('_', ' ').title()}"
+
+                create_comparison_plot(
+                    in_network_agg,
+                    out_network_agg,
+                    "week",
+                    label_col,
+                    output_path,
+                    title,
+                    ylabel,
+                )
+        else:
+            logger.error("Failed to load weekly data")
+
+    # Print summary
+    logger.info("=== VISUALIZATION SUMMARY ===")
+    logger.info(f"Output directory: {output_dir}")
+
+    # Count generated files
+    png_files = [f for f in os.listdir(output_dir) if f.endswith(".png")]
+    logger.info(f"Generated {len(png_files)} visualization files:")
+    for file in sorted(png_files):
+        logger.info(f"  - {file}")
+
+    logger.info(f"All visualization assets saved in: {output_dir}")
+    logger.info("In-network vs out-of-network feed content visualization complete")
+
+
+def main():
+    """
+    Main execution function for visualization.
+    """
+    try:
+        create_visualizations()
+    except Exception as e:
+        logger.error(f"Error in visualization: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements comprehensive analysis comparing content labels between in-network and out-of-network posts used in feeds.

**Changes**:
- Add main.py with command line flag support for network type filtering (--network_type in_network/out_of_network)
- Add visualize_results.py for comparison time series plots with overlay visualization
- Add Slurm scripts for cluster execution (submit_in_network_analysis.sh and submit_out_of_network_analysis.sh)
- Add comprehensive README with usage instructions and expected insights
- Filter posts by is_in_network flag from feed JSON data
- Generate timestamped CSV exports and visualization overlays
- Support all content labels (toxicity, constructive, political, IME, valence, etc.)

**Features**:
- Command line interface for easy execution
- Network type filtering based on social connections
- Daily and weekly aggregation levels
- Comprehensive visualization with condition-based color coding
- Slurm integration for cluster execution
- Timestamped output organization

**Usage**:
1. Run both Slurm scripts: `sbatch submit_in_network_analysis.sh` and `sbatch submit_out_of_network_analysis.sh`
2. Generate visualizations: `python visualize_results.py`

This analysis will reveal differences in content characteristics between in-network and out-of-network posts, helping understand echo chamber effects, content quality differences, and political polarization patterns in personalized feeds.