### PR TITLE
Fix Glue table for "archive_generated_feeds" by updating S3 path

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3652,7 +3652,7 @@ resource "aws_glue_catalog_table" "archive_generated_feeds" {
   }
 
   storage_descriptor {
-    location      = "s3://${var.s3_root_bucket_name}/bluesky_research/2024_nature_paper_study_data/generated_feeds/"
+    location      = "s3://${var.s3_root_bucket_name}/bluesky_research/2024_nature_paper_study_data/generated_feeds/cache/"
     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
 


### PR DESCRIPTION
The S3 path for the "archive_generated_feeds" table was `s3://.../generated_feeds/` when it should've been `s3://.../generated_feeds/cache/`. This led to the table having 0 results.

This bug fix updates the Glue schema.

Verification from Athena console:
<img width="1295" height="365" alt="Screenshot 2026-01-06 at 9 14 25 AM" src="https://github.com/user-attachments/assets/445b30ff-7a30-452c-85d1-0bbf6902a2cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage location configuration for archived data in cloud infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->