### PR TITLE
Fix remaining incorrect S3 paths for Glue schemas

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3717,7 +3717,7 @@ resource "aws_glue_catalog_table" "archive_in_network_user_activity" {
   }
 
   storage_descriptor {
-    location      = "s3://${var.s3_root_bucket_name}/bluesky_research/2024_nature_paper_study_data/in_network_user_activity/"
+    location      = "s3://${var.s3_root_bucket_name}/bluesky_research/2024_nature_paper_study_data/in_network_user_activity/cache/"
     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
 


### PR DESCRIPTION
# PR description

In https://github.com/METResearchGroup/bluesky-research/pull/279, we fixed an issue where the Glue metadata for a table was pointing at the wrong S3 path. We resolved it but found that other tables have the same issue. In this PR, we make the associated fixes.

I verified that only `archive_fetch_posts_used_in_feeds` and `archive_in_network_user_activity` have these bugs; the rest have correct filepaths.

## Validating the fix for `archive_fetch_posts_used_in_feeds`

Before:

<img width="1282" height="582" alt="Screenshot 2026-01-06 at 9 57 36 AM" src="https://github.com/user-attachments/assets/97ebe261-e884-472d-8d8d-4379f13227b0" />

After deploying Terraform fix and running `MSCK REPAIR TABLE archive_fetch_posts_used_in_feeds;`:

<img width="1283" height="583" alt="Screenshot 2026-01-06 at 9 58 21 AM" src="https://github.com/user-attachments/assets/db88f09e-3214-4162-bf96-5ed0fc30a436" />

## Validating the fix for `archive_in_network_user_activity`

Before:

<img width="1287" height="538" alt="Screenshot 2026-01-06 at 10 00 09 AM" src="https://github.com/user-attachments/assets/fa38fef9-3707-4a3d-af5b-c425132f1433" />

After deploying Terraform fix and running `MSCK REPAIR TABLE archive_in_network_user_activity;`

<img width="1286" height="582" alt="Screenshot 2026-01-06 at 10 04 17 AM" src="https://github.com/user-attachments/assets/729b7512-43e7-4b8b-b4c4-ce78ab5fd689" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage locations for archived research data tables as part of infrastructure configuration adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->