### PR TITLE
Prevent import-time Bluesky client initialization by lazy-importing transform.bluesky_helper in manual_excludelist.py.

### DIFF
--- a/services/preprocess_raw_data/classify_nsfw_content/manual_excludelist.py
+++ b/services/preprocess_raw_data/classify_nsfw_content/manual_excludelist.py
@@ -4,8 +4,6 @@ import os
 
 import pandas as pd
 
-from transform.bluesky_helper import get_author_did_from_handle
-
 NSFW_HANDLES = [
     "ruffusbleu.bsky.social",
     "fujiyamasamoyed.bsky.social",
@@ -202,6 +200,13 @@ def load_users_to_exclude() -> dict[str, set]:
 
 
 def get_dids_to_exclude(load_existing_exclusions: bool = False) -> list[str]:
+    # NOTE:
+    # Importing `transform.bluesky_helper` can pull in Bluesky client setup via
+    # transitive imports. To avoid any import-time side effects for modules that
+    # only need the excludelist data (e.g. rank_score_feeds), we import the DID
+    # resolver lazily at runtime.
+    from transform.bluesky_helper import get_author_did_from_handle
+
     if load_existing_exclusions:
         users_to_exclude: pd.DataFrame = load_users_from_csv()
     else:

--- a/services/rank_score_feeds/tests/test_import_side_effects.py
+++ b/services/rank_score_feeds/tests/test_import_side_effects.py
@@ -1,0 +1,24 @@
+"""Regression tests for import-time side effects.
+
+Issue #267: `rank_score_feeds` imports `manual_excludelist` for CSV-based exclusions.
+That module must remain safe to import without importing `transform.bluesky_helper`
+and triggering any Bluesky client initialization.
+"""
+
+import importlib
+import sys
+
+
+def test_manual_excludelist_import_does_not_import_bluesky_helper():
+    # Ensure a clean slate for this assertion within the pytest process.
+    sys.modules.pop(
+        "services.preprocess_raw_data.classify_nsfw_content.manual_excludelist", None
+    )
+    sys.modules.pop("transform.bluesky_helper", None)
+
+    importlib.import_module(
+        "services.preprocess_raw_data.classify_nsfw_content.manual_excludelist"
+    )
+
+    assert "transform.bluesky_helper" not in sys.modules
+


### PR DESCRIPTION
Prevent import-time Bluesky client initialization by lazy-importing `transform.bluesky_helper` in `manual_excludelist.py`.

Fixes https://github.com/METResearchGroup/bluesky-research/issues/267
---
<a href="https://cursor.com/background-agent?bcId=bc-781d8c85-8a0d-416e-8751-7d3e9312db2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-781d8c85-8a0d-416e-8751-7d3e9312db2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal module initialization by deferring handle resolution operations to runtime instead of module load time, reducing unnecessary processing during startup.

* **Tests**
  * Added regression test to verify that module imports do not trigger unintended side effects or inadvertently activate unnecessary dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->