### PR TITLE
Move data loading logic outside of `FeedGenerationOrchestrator`

### DIFF
--- a/services/rank_score_feeds/orchestrator.py
+++ b/services/rank_score_feeds/orchestrator.py
@@ -235,14 +235,11 @@ class FeedGenerationOrchestrator:
         Returns:
             LoadedData with filtered and deduplicated posts.
         """
-        # Load all data
+        # Load all data with deduplication
         loaded_data = self.feed_data_loader.load_complete_data(
-            test_mode=test_mode, users_to_create_feeds_for=users_to_create_feeds_for
-        )
-
-        # Deduplicate and filter posts
-        loaded_data.posts_df = self.feed_data_loader.deduplicate_and_filter_posts(
-            loaded_data.posts_df
+            test_mode=test_mode,
+            users_to_create_feeds_for=users_to_create_feeds_for,
+            deduplicate_posts=True,
         )
 
         return loaded_data

--- a/services/rank_score_feeds/tests/test_orchestrator.py
+++ b/services/rank_score_feeds/tests/test_orchestrator.py
@@ -59,11 +59,8 @@ class TestFeedGenerationOrchestrator:
 
         with patch.object(
             orchestrator.feed_data_loader, "load_complete_data"
-        ) as mock_load_complete, patch.object(
-            orchestrator.feed_data_loader, "deduplicate_and_filter_posts"
-        ) as mock_dedup:
+        ) as mock_load_complete:
             mock_load_complete.return_value = mock_loaded_data
-            mock_dedup.return_value = mock_posts_df
 
             # Act
             result = orchestrator._load_data(test_mode=False, users_to_create_feeds_for=None)
@@ -76,9 +73,8 @@ class TestFeedGenerationOrchestrator:
             assert result.previous_feeds == mock_loaded_data.previous_feeds
             assert result.study_users == mock_loaded_data.study_users
             mock_load_complete.assert_called_once_with(
-                test_mode=False, users_to_create_feeds_for=None
+                test_mode=False, users_to_create_feeds_for=None, deduplicate_posts=True
             )
-            mock_dedup.assert_called_once_with(mock_posts_df)
 
     def test_load_data_filters_users_when_specified(self):
         """Verify _load_data filters users correctly."""
@@ -107,11 +103,8 @@ class TestFeedGenerationOrchestrator:
 
         with patch.object(
             orchestrator.feed_data_loader, "load_complete_data"
-        ) as mock_load_complete, patch.object(
-            orchestrator.feed_data_loader, "deduplicate_and_filter_posts"
-        ) as mock_dedup:
+        ) as mock_load_complete:
             mock_load_complete.return_value = mock_loaded_data
-            mock_dedup.return_value = pd.DataFrame()
 
             # Act
             result = orchestrator._load_data(
@@ -122,7 +115,9 @@ class TestFeedGenerationOrchestrator:
             assert len(result.study_users) == 1
             assert result.study_users[0].bluesky_handle == "user1.bsky.social"
             mock_load_complete.assert_called_once_with(
-                test_mode=False, users_to_create_feeds_for=["user1.bsky.social"]
+                test_mode=False,
+                users_to_create_feeds_for=["user1.bsky.social"],
+                deduplicate_posts=True,
             )
 
     def test_score_posts_delegates_to_scoring_service(self):


### PR DESCRIPTION
Fixes https://github.com/METResearchGroup/bluesky-research/issues/282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the feed data pipeline for clearer, centralized loading and transformation.
  * Consolidated multiple legacy loading steps into a single, consistent data-loading flow.
  * Preserved existing orchestration behavior while simplifying internal flow.

* **Bug Fixes**
  * Improved post deduplication and author exclusion to reduce duplicate or unwanted items in feeds.

* **Tests**
  * Expanded test coverage for loading, transformation, deduplication, and end-to-end feed preparation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->