### PR TITLE
Remove bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,21 +8,6 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.2
-    hooks:
-      - id: bandit
-        args:
-          [
-            "-r",
-            ".",
-            "--exclude",
-            "*/.git/*,*/.venv/*,*/venv/*,*/build/*,*/dist/*,*/node_modules/*,*/assets/*,*/demos/*,*/experiments/*,*/deprecated/*,*/terraform/*,*/tests/*,*/demo/*",
-            "--severity-level",
-            "medium",
-            "--confidence-level",
-            "medium",
-          ]
   - repo: https://github.com/rohaquinlop/complexipy-pre-commit
     rev: v3.0.0
     hooks:


### PR DESCRIPTION
Remove the `bandit` pre-commit hook to prevent local failures and streamline development, as security checks are already covered in CI.

The current `bandit` pre-commit hook is misconfigured and fails when passed file paths, blocking local commits. Since Bandit is already run as part of the CI pipeline (`.github/workflows/python-ci.yml`), its presence in pre-commit is redundant and causes friction. Removing it simplifies the local development workflow without compromising security scanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1b15497-dde7-43e4-a294-7bf2a97a4e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1b15497-dde7-43e4-a294-7bf2a97a4e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Bandit security analysis tool from the pre-commit hook configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->