### PR TITLE
Type checker replacement with ty

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,6 +54,20 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         uv run ruff check .
+
+    - name: Type check with ty (non-blocking)
+      run: |
+        # Non-blocking until the repo is fully type-clean; still surfaces diagnostics in CI logs/annotations.
+        uv run ty check \
+          --output-format github \
+          --respect-ignore-files \
+          --exclude "**/*.ipynb" \
+          --exclude "assets/" \
+          --exclude "demos/" \
+          --exclude "deprecated/" \
+          --exclude "experiments/" \
+          --exclude "terraform/" \
+          --exit-zero
     - name: Bandit security scan
       run: |
         uv run bandit -r . \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
     rev: v3.0.0
     hooks:
       - id: complexipy
+  - repo: local
+    hooks:
+      - id: ty-check
+        name: ty check (non-blocking)
+        entry: uv run ty check --output-format concise --respect-ignore-files --exclude "**/*.ipynb" --exclude "assets/" --exclude "demos/" --exclude "deprecated/" --exclude "experiments/" --exclude "terraform/" --exit-zero
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-xdist>=3.5.0",
     "ruff>=0.4.5",
+    "ty",
     "bandit>=1.9.2",
     "vulture>=2.11.0",
     "autopep8>=2.1.0",


### PR DESCRIPTION
Add `ty` for type checking in CI and as a pre-commit hook to fulfill issue #239's intent.

The original issue intended to add `pyright` to CI, but `pyright` was not actively run. This PR implements type checking using `ty` instead, configured as non-blocking in both CI and pre-commit to allow for gradual type-cleanliness while still surfacing diagnostics.

---
<a href="https://cursor.com/background-agent?bcId=bc-b219367f-880b-4cdc-a06b-3f683f4b1ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b219367f-880b-4cdc-a06b-3f683f4b1ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development toolchain with integrated type checking across the CI/CD pipeline and pre-commit workflow to improve code quality assurance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->