### PR TITLE
Decouple the backfill app from the `--record-type` arg

### DIFF
--- a/pipelines/backfill_records_coordination/HOW_TO_DO_BACKFILL_E2E.md
+++ b/pipelines/backfill_records_coordination/HOW_TO_DO_BACKFILL_E2E.md
@@ -2,11 +2,52 @@
 
 ## Problem statement
 
-## Step 1: Add new data to the corresponding input queue
+## How to run the CLI tool
 
-## Step 2: Run the service on the data from the input queue
+In `pipelines/backfill_records_coordination/app.py`, the CLI tool...
 
-## Step 3: Take the data from the output queue and write to permanent storage
+It supports 3 modes:
+
+1. Adding posts to queue, to await backfill/
+2. Run the integration(s).
+3. Write the records from cache to permanent storage.
+
+### Mode 1 (`--add-to-queue`): Add posts to queue, to be pending backfill
+
+We can pick our source for posts that we want to enqueue for backfill.
+
+There are two sources we support here:
+
+1. `--record-type posts`: we enqueue all of our available posts as pending backfill (subtracting any posts that have been backfilled already for that integration).
+2. `--record-type posts_used_in_feeds`: we enqueue all of the posts that were used in feeds (subtracting any posts that have been backfilled already for that integration).
+
+For example, for the following command:
+
+```bash
+python app.py --record-type posts --integration ml_inference_perspective_api --add-to-queue
+```
+
+We add all posts to the input queue for the `ml_inference_perspective_api` integration, subtracting any posts that we've previously classified.
+
+### Mode 2: Running integrations
+
+For example, in the following command:
+
+```bash
+python app.py --record-type posts --integration ml_inference_perspective_api --run-integrations
+```
+
+We run the integration on whatever records are currently queued.
+
+You can also omit `--record-type` when you are only running integrations (i.e., not enqueueing).
+In that case, you must specify at least one `--integration`:
+
+```bash
+python app.py --integration ml_inference_perspective_api --run-integrations
+```
+
+
+### Mode 3: Writing cached records to permanent storage
 
 ## FAQs
 

--- a/pipelines/backfill_records_coordination/app.py
+++ b/pipelines/backfill_records_coordination/app.py
@@ -268,6 +268,10 @@ def backfill_records(
     if add_to_queue and not record_type:
         raise click.UsageError("--record-type is required when --add-to-queue is used")
 
+    # Running integrations always requires explicit integrations (avoid accidental "run everything").
+    if run_integrations and (not integration):
+        raise click.UsageError("--integration is required when --run-integrations is used")
+
     # Validate that posts_used_in_feeds requires both start_date and end_date
     if record_type == "posts_used_in_feeds":
         if not (start_date and end_date):

--- a/pipelines/backfill_records_coordination/example_payloads.py
+++ b/pipelines/backfill_records_coordination/example_payloads.py
@@ -29,6 +29,10 @@ payloads = {
         "description": "Run integrations only (process existing queued records)",
         "command": "python app.py --record-type posts --integration ml_inference_perspective_api --run-integrations",
     },
+    "perspective_api_run_integration_only_no_record_type": {
+        "description": "Run integrations only (process existing queued records). Works the same with or without the `--record-type` flag.",
+        "command": "python app.py --integration ml_inference_perspective_api --run-integrations",
+    },
     "perspective_api_trigger_write_cache_buffers_to_db": {
         "description": "Write cache buffers to database for Perspective API",
         "command": "python app.py --record-type posts --write-cache ml_inference_perspective_api",

--- a/pipelines/backfill_records_coordination/tests/test_app.py
+++ b/pipelines/backfill_records_coordination/tests/test_app.py
@@ -232,6 +232,16 @@ class TestBackfillCoordinationCliApp(TestCase):
                             "backfill_period": None,
                             "backfill_duration": None,
                             "run_classification": True
+                        },
+                        "ml_inference_valence_classifier": {
+                            "backfill_period": None,
+                            "backfill_duration": None,
+                            "run_classification": True
+                        },
+                        "ml_inference_intergroup": {
+                            "backfill_period": None,
+                            "backfill_duration": None,
+                            "run_classification": True
                         }
                     },
                     "start_date": None,
@@ -243,7 +253,7 @@ class TestBackfillCoordinationCliApp(TestCase):
         
     @patch('pipelines.backfill_records_coordination.app.lambda_handler')
     def test_run_only_no_queue(self, mock_handler):
-        """Test running integrations without adding to queue."""
+        """Test validation: run_integrations without record_type requires explicit integrations."""
         mock_handler.return_value = {"statusCode": 200}
         
         result = self.runner.invoke(
@@ -251,36 +261,12 @@ class TestBackfillCoordinationCliApp(TestCase):
             ['--run-integrations']
         )
         
-        self.assertEqual(result.exit_code, 0)
-        mock_handler.assert_called_once_with(
-            {
-                "payload": {
-                    "record_type": None,
-                    "add_posts_to_queue": False,
-                    "run_integrations": True,
-                    "integration_kwargs": {
-                        "ml_inference_perspective_api": {
-                            "backfill_period": None,
-                            "backfill_duration": None,
-                            "run_classification": True
-                        },
-                        "ml_inference_sociopolitical": {
-                            "backfill_period": None,
-                            "backfill_duration": None,
-                            "run_classification": True
-                        },
-                        "ml_inference_ime": {
-                            "backfill_period": None,
-                            "backfill_duration": None,
-                            "run_classification": True
-                        }
-                    },
-                    "start_date": None,
-                    "end_date": None
-                }
-            },
-            None
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn(
+            "--integration is required when --run-integrations is used",
+            result.output,
         )
+        mock_handler.assert_not_called()
 
     @patch('pipelines.backfill_records_coordination.app.lambda_handler')
     @patch('pipelines.backfill_records_coordination.app.write_cache_handler')
@@ -431,6 +417,7 @@ class TestBackfillCoordinationCliApp(TestCase):
             backfill_records,
             [
                 '--record-type', 'posts',
+                '-i', 'p',
                 '--start-date', '2024-01-01',
                 '--end-date', '2024-01-31',
                 '--add-to-queue',
@@ -450,18 +437,9 @@ class TestBackfillCoordinationCliApp(TestCase):
                             "backfill_period": None,
                             "backfill_duration": None,
                             "run_classification": True
-                        },
-                        "ml_inference_sociopolitical": {
-                            "backfill_period": None,
-                            "backfill_duration": None,
-                            "run_classification": True
-                        },
-                        "ml_inference_ime": {
-                            "backfill_period": None,
-                            "backfill_duration": None,
-                            "run_classification": True
                         }
                     },
+                    "integration": ["ml_inference_perspective_api"],
                     "start_date": "2024-01-01",
                     "end_date": "2024-01-31"
                 }
@@ -516,6 +494,16 @@ class TestBackfillCoordinationCliApp(TestCase):
                             "run_classification": True
                         },
                         "ml_inference_ime": {
+                            "backfill_period": None,
+                            "backfill_duration": None,
+                            "run_classification": True
+                        },
+                        "ml_inference_valence_classifier": {
+                            "backfill_period": None,
+                            "backfill_duration": None,
+                            "run_classification": True
+                        },
+                        "ml_inference_intergroup": {
                             "backfill_period": None,
                             "backfill_duration": None,
                             "run_classification": True
@@ -594,6 +582,7 @@ class TestBackfillCoordinationCliApp(TestCase):
             [
                 '--write-cache', 'all',
                 '--record-type', 'posts',
+                '-i', 'p',
                 '--add-to-queue',
                 '--run-integrations'
             ]

--- a/services/backfill/main.py
+++ b/services/backfill/main.py
@@ -32,6 +32,23 @@ def backfill_records(payload: dict):
         }
     """
     record_type = payload.get("record_type")
+    add_posts_to_queue = bool(payload.get("add_posts_to_queue"))
+    run_integrations = bool(payload.get("run_integrations"))
+
+    # Support running integrations without a record_type (run-only mode).
+    # In this mode, we don't enqueue anything; we simply trigger integrations to
+    # process whatever is already queued.
+    if record_type is None:
+        if add_posts_to_queue:
+            raise ValueError(
+                "record_type is required when add_posts_to_queue is True. "
+                "Specify --record-type when enqueueing."
+            )
+        if run_integrations:
+            backfill_posts(payload)
+            return
+        raise ValueError("Unsupported record type: None")
+
     if record_type == "posts":
         backfill_posts(payload)
     elif record_type == "posts_used_in_feeds":


### PR DESCRIPTION
# PR Description

In our current backfill CLI app, `pipelines/backfill_records_coordination/app.py`, we require `--record-type` to be added as a command line flag, irrespective of if we're enqueueing posts or not. The flag is only used when we determine the sort of post that we're enqueueing, and no other reason, so we should remove the requirement of adding this flag for all queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive end-to-end backfill workflow guide with CLI examples and operation modes.

* **New Features**
  * Ability to run integrations without specifying a record type.

* **Improvements**
  * Validation now requires explicit integration selection when running integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->