### PR TITLE
Simplify backfill CLI interface

### DIFF
--- a/pipelines/backfill_records_coordination/HOW_TO_DO_BACKFILL_E2E.md
+++ b/pipelines/backfill_records_coordination/HOW_TO_DO_BACKFILL_E2E.md
@@ -24,7 +24,7 @@ There are two sources we support here:
 For example, for the following command:
 
 ```bash
-python app.py --record-type posts --integration ml_inference_perspective_api --add-to-queue
+python app.py --record-type posts --integrations ml_inference_perspective_api --add-to-queue
 ```
 
 We add all posts to the input queue for the `ml_inference_perspective_api` integration, subtracting any posts that we've previously classified.
@@ -34,16 +34,16 @@ We add all posts to the input queue for the `ml_inference_perspective_api` integ
 For example, in the following command:
 
 ```bash
-python app.py --record-type posts --integration ml_inference_perspective_api --run-integrations
+python app.py --record-type posts --integrations ml_inference_perspective_api --run-integrations
 ```
 
 We run the integration on whatever records are currently queued.
 
 You can also omit `--record-type` when you are only running integrations (i.e., not enqueueing).
-In that case, you must specify at least one `--integration`:
+In that case, you must specify at least one `--integrations`:
 
 ```bash
-python app.py --integration ml_inference_perspective_api --run-integrations
+python app.py --integrations ml_inference_perspective_api --run-integrations
 ```
 
 

--- a/pipelines/backfill_records_coordination/app.py
+++ b/pipelines/backfill_records_coordination/app.py
@@ -79,7 +79,7 @@ def validate_date_format(ctx, param, value):
     help="Run the integrations after queueing",
 )
 @click.option(
-    "--integration",
+    "--integrations",
     "-i",
     type=click.Choice(
         [
@@ -175,7 +175,7 @@ def backfill_records(
     record_type: str | None,
     add_to_queue: bool,
     run_integrations: bool,
-    integration: tuple[str, ...],
+    integrations: tuple[str, ...],
     backfill_period: str | None,
     backfill_duration: int | None,
     run_classification: bool,
@@ -217,10 +217,6 @@ def backfill_records(
         # Clear output queues for specific integrations
         $ python -m pipelines.backfill_records_coordination.app -i p -i s --clear-output-queues
     """
-    # TODO: change name of 'integration' to 'integrations' since it can take
-    # multiple integrations...
-    integrations = integration
-
     mapped_integration_names: list[str] = _resolve_integration_names(integrations)
 
     # first, we clear out the queues (if the user requested it).
@@ -238,7 +234,7 @@ def backfill_records(
         add_to_queue=add_to_queue,
         record_type=record_type,
         run_integrations=run_integrations,
-        integration=integration,
+        integrations=integrations,
         write_cache=write_cache,
         clear_queue=clear_queue,
         bypass_write=bypass_write,
@@ -394,7 +390,7 @@ def run_validation_checks(
     add_to_queue: bool,
     record_type: str | None,
     run_integrations: bool,
-    integration: tuple[str, ...],
+    integrations: tuple[str, ...],
     write_cache: str | None,
     clear_queue: bool,
     bypass_write: bool,
@@ -407,9 +403,9 @@ def run_validation_checks(
         raise click.UsageError("--record-type is required when --add-to-queue is used")
 
     # Running integrations always requires explicit integrations (avoid accidental "run everything").
-    if run_integrations and (not integration):
+    if run_integrations and (not integrations):
         raise click.UsageError(
-            "--integration is required when --run-integrations is used"
+            "--integrations is required when --run-integrations is used"
         )
 
     # Validate that posts_used_in_feeds requires both start_date and end_date

--- a/pipelines/backfill_records_coordination/example_payloads.py
+++ b/pipelines/backfill_records_coordination/example_payloads.py
@@ -23,15 +23,15 @@ payloads = {
     },
     "perspective_api_enqueue_only": {
         "description": "Enqueue records only, skip running integrations",
-        "command": "python app.py --record-type posts --integration ml_inference_perspective_api --add-to-queue",
+        "command": "python app.py --record-type posts --integrations ml_inference_perspective_api --add-to-queue",
     },
     "perspective_api_run_integration_only": {
         "description": "Run integrations only (process existing queued records)",
-        "command": "python app.py --record-type posts --integration ml_inference_perspective_api --run-integrations",
+        "command": "python app.py --record-type posts --integrations ml_inference_perspective_api --run-integrations",
     },
     "perspective_api_run_integration_only_no_record_type": {
         "description": "Run integrations only (process existing queued records). Works the same with or without the `--record-type` flag.",
-        "command": "python app.py --integration ml_inference_perspective_api --run-integrations",
+        "command": "python app.py --integrations ml_inference_perspective_api --run-integrations",
     },
     "perspective_api_trigger_write_cache_buffers_to_db": {
         "description": "Write cache buffers to database for Perspective API",
@@ -39,11 +39,11 @@ payloads = {
     },
     "sociopolitical_enqueue_only": {
         "description": "Enqueue records only, skip running integrations",
-        "command": "python app.py --record-type posts --integration ml_inference_sociopolitical --add-to-queue",
+        "command": "python app.py --record-type posts --integrations ml_inference_sociopolitical --add-to-queue",
     },
     "sociopolitical_run_integration_only": {
         "description": "Run integrations only (process existing queued records)",
-        "command": "python app.py --record-type posts --integration ml_inference_sociopolitical --run-integrations",
+        "command": "python app.py --record-type posts --integrations ml_inference_sociopolitical --run-integrations",
     },
     "sociopolitical_trigger_write_cache_buffers_to_db": {
         "description": "Write cache buffers to database for Sociopolitical",
@@ -51,11 +51,11 @@ payloads = {
     },
     "ime_enqueue_only": {
         "description": "Enqueue records only, skip running integrations",
-        "command": "python app.py --record-type posts --integration ml_inference_ime --add-to-queue",
+        "command": "python app.py --record-type posts --integrations ml_inference_ime --add-to-queue",
     },
     "ime_run_integration_only": {
         "description": "Run integrations only (process existing queued records)",
-        "command": "python app.py --record-type posts --integration ml_inference_ime --run-integrations",
+        "command": "python app.py --record-type posts --integrations ml_inference_ime --run-integrations",
     },
     "ime_trigger_write_cache_buffers_to_db": {
         "description": "Write cache buffers to database for IME",

--- a/pipelines/backfill_records_coordination/tests/test_app.py
+++ b/pipelines/backfill_records_coordination/tests/test_app.py
@@ -263,7 +263,7 @@ class TestBackfillCoordinationCliApp(TestCase):
         
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn(
-            "--integration is required when --run-integrations is used",
+            "--integrations is required when --run-integrations is used",
             result.output,
         )
         mock_handler.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ include = [
     "services*",
     "transform*",
     "query_interface*",
+    "pipelines*",
 ]
 exclude = [
     "demos*", 


### PR DESCRIPTION
# PR Description

Currently we have an overly complicated CLI file for running the backfill. This PR greatly simplifies that CLI file while not changing any of the functionality. It moves things to a helper function that makes more clear what's happening in the main API. It also changes the name of one of the flags from integration to integrations, making it more explicitly clear that it can take multiple at a time. We are pending other subsequent refactors as well that will be larger in scope and will more broadly continue our refactor of the backfill service. 