### PR TITLE
Implement `S3Adapter.load_feed_posts`

### DIFF
--- a/services/backfill/repositories/adapters.py
+++ b/services/backfill/repositories/adapters.py
@@ -2,12 +2,7 @@
 
 import pandas as pd
 
-from lib.constants import FEED_LOOKBACK_DAYS_DURING_STUDY, study_start_date
 from lib.db.models import StorageTier
-from lib.datetime_utils import (
-    calculate_start_end_date_for_lookback,
-    get_partition_dates,
-)
 from lib.db.manage_s3_data import S3ParquetBackend, S3ParquetDatasetRef
 from lib.db.manage_local_data import load_data_from_local_storage
 from lib.log.logger import get_logger
@@ -65,57 +60,6 @@ class LocalStorageAdapter(BackfillDataAdapter):
         dumped_posts: list[dict] = cached_df.to_dict(orient="records")
         return [PostToEnqueueModel(**post) for post in dumped_posts]
 
-    def load_feed_posts(
-        self, start_date: str, end_date: str
-    ) -> list[PostToEnqueueModel]:
-        """Load feed posts from local storage.
-
-        Args:
-            start_date: Start date in YYYY-MM-DD format (inclusive)
-            end_date: End date in YYYY-MM-DD format (inclusive)
-        """
-        results: list[PostToEnqueueModel] = []
-        partition_dates: list[str] = get_partition_dates(
-            start_date=start_date, end_date=end_date
-        )
-        for partition_date in partition_dates:
-            results.extend(self._load_feed_posts_for_date(partition_date))
-        deduplicated_results: list[PostToEnqueueModel] = self._deduplicate_feed_posts(
-            posts=results
-        )
-        return deduplicated_results
-
-    def _load_feed_posts_for_date(
-        self, partition_date: str
-    ) -> list[PostToEnqueueModel]:
-        """Load the posts used in the feeds for a given date."""
-
-        posts_used_in_feeds: list[PostUsedInFeedModel] = (
-            self._load_posts_used_in_feeds_for_date(partition_date)
-        )
-
-        lookback_start_date, lookback_end_date = calculate_start_end_date_for_lookback(
-            partition_date=partition_date,
-            num_days_lookback=FEED_LOOKBACK_DAYS_DURING_STUDY,
-            min_lookback_date=study_start_date,
-        )
-
-        candidate_pool_posts: list[PostToEnqueueModel] = (
-            self._load_candidate_pool_posts_for_date(
-                lookback_start_date=lookback_start_date,
-                lookback_end_date=lookback_end_date,
-            )
-        )
-
-        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = (
-            self._get_candidate_pool_posts_used_in_feeds_for_date(
-                candidate_pool_posts=candidate_pool_posts,
-                posts_used_in_feeds=posts_used_in_feeds,
-            )
-        )
-
-        return candidate_pool_posts_used_in_feeds
-
     def _load_posts_used_in_feeds_for_date(
         self, partition_date: str
     ) -> list[PostUsedInFeedModel]:
@@ -138,54 +82,6 @@ class LocalStorageAdapter(BackfillDataAdapter):
         )
         dumped_posts: list[dict] = cached_df.to_dict(orient="records")
         return [PostUsedInFeedModel(**post) for post in dumped_posts]
-
-    def _load_candidate_pool_posts_for_date(
-        self,
-        lookback_start_date: str,
-        lookback_end_date: str,
-    ) -> list[PostToEnqueueModel]:
-        """For feeds from a given date, load the posts that would've been
-        a part of the candidate pool for that date.
-
-        We need to reconstruct in this way because at the level of the feeds,
-        we only have the post URIs, so we need to artificially reconstruct
-        the candidate pool posts from the post URIs in order to have fully
-        hydrated posts.
-        """
-        return self.load_all_posts(
-            start_date=lookback_start_date,
-            end_date=lookback_end_date,
-        )
-
-    def _get_candidate_pool_posts_used_in_feeds_for_date(
-        self,
-        candidate_pool_posts: list[PostToEnqueueModel],
-        posts_used_in_feeds: list[PostUsedInFeedModel],
-    ) -> list[PostToEnqueueModel]:
-        """Get the candidate pool posts used in the feeds for a given date."""
-        uris_of_posts_used_in_feeds: set[str] = {
-            post.uri for post in posts_used_in_feeds
-        }
-        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = [
-            post
-            for post in candidate_pool_posts
-            if post.uri in uris_of_posts_used_in_feeds
-        ]
-        return candidate_pool_posts_used_in_feeds
-
-    def _deduplicate_feed_posts(
-        self, posts: list[PostToEnqueueModel]
-    ) -> list[PostToEnqueueModel]:
-        """Deduplicate feed posts. A post can be used in feeds across multiple
-        dates, so we just want to grab one version of the post.
-        """
-        unique_uris: set[str] = set()
-        filtered_results: list[PostToEnqueueModel] = []
-        for post in posts:
-            if post.uri not in unique_uris:
-                unique_uris.add(post.uri)
-                filtered_results.append(post)
-        return filtered_results
 
     def get_previously_labeled_post_uris(
         self,
@@ -284,11 +180,7 @@ class LocalStorageAdapter(BackfillDataAdapter):
 
 
 class S3Adapter(BackfillDataAdapter):
-    """S3 adapter implementation.
-
-    Mirrors the LocalStorageAdapter interface but loads Parquet from the
-    study dataset S3 layout via S3ParquetBackend + DuckDB.
-    """
+    """S3 adapter implementation."""
 
     def __init__(self, backend: S3ParquetBackend | None = None):
         self.backend = backend or S3ParquetBackend()
@@ -326,66 +218,6 @@ class S3Adapter(BackfillDataAdapter):
         dumped_posts: list[dict] = df.to_dict(orient="records")
         return [PostToEnqueueModel(**post) for post in dumped_posts]
 
-    def load_feed_posts(
-        self, start_date: str, end_date: str
-    ) -> list[PostToEnqueueModel]:
-        """Load feed posts from S3.
-
-        Args:
-            start_date: Start date in YYYY-MM-DD format (inclusive)
-            end_date: End date in YYYY-MM-DD format (inclusive)
-
-        Returns:
-            list[PostToEnqueueModel]: List of deduplicated feed posts.
-        """
-        try:
-            results: list[PostToEnqueueModel] = []
-            partition_dates: list[str] = get_partition_dates(
-                start_date=start_date, end_date=end_date
-            )
-            for partition_date in partition_dates:
-                results.extend(self._load_feed_posts_for_date(partition_date))
-            deduplicated_results: list[PostToEnqueueModel] = (
-                self._deduplicate_feed_posts(posts=results)
-            )
-            return deduplicated_results
-        except BackfillDataAdapterError:
-            raise
-        except Exception as e:
-            raise BackfillDataAdapterError(
-                f"Failed to load feed posts from S3: {e}"
-            ) from e
-
-    def _load_feed_posts_for_date(
-        self, partition_date: str
-    ) -> list[PostToEnqueueModel]:
-        """Load the posts used in the feeds for a given date."""
-        posts_used_in_feeds: list[PostUsedInFeedModel] = (
-            self._load_posts_used_in_feeds_for_date(partition_date)
-        )
-
-        lookback_start_date, lookback_end_date = calculate_start_end_date_for_lookback(
-            partition_date=partition_date,
-            num_days_lookback=FEED_LOOKBACK_DAYS_DURING_STUDY,
-            min_lookback_date=study_start_date,
-        )
-
-        candidate_pool_posts: list[PostToEnqueueModel] = (
-            self._load_candidate_pool_posts_for_date(
-                lookback_start_date=lookback_start_date,
-                lookback_end_date=lookback_end_date,
-            )
-        )
-
-        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = (
-            self._get_candidate_pool_posts_used_in_feeds_for_date(
-                candidate_pool_posts=candidate_pool_posts,
-                posts_used_in_feeds=posts_used_in_feeds,
-            )
-        )
-
-        return candidate_pool_posts_used_in_feeds
-
     def _load_posts_used_in_feeds_for_date(
         self, partition_date: str
     ) -> list[PostUsedInFeedModel]:
@@ -415,54 +247,6 @@ class S3Adapter(BackfillDataAdapter):
             raise BackfillDataAdapterError(
                 f"Failed to load posts used in feeds from S3 for partition_date={partition_date}: {e}"
             ) from e
-
-    def _load_candidate_pool_posts_for_date(
-        self,
-        lookback_start_date: str,
-        lookback_end_date: str,
-    ) -> list[PostToEnqueueModel]:
-        """For feeds from a given date, load the posts that would've been
-        a part of the candidate pool for that date.
-
-        We need to reconstruct in this way because at the level of the feeds,
-        we only have the post URIs, so we need to artificially reconstruct
-        the candidate pool posts from the post URIs in order to have fully
-        hydrated posts.
-        """
-        return self.load_all_posts(
-            start_date=lookback_start_date,
-            end_date=lookback_end_date,
-        )
-
-    def _get_candidate_pool_posts_used_in_feeds_for_date(
-        self,
-        candidate_pool_posts: list[PostToEnqueueModel],
-        posts_used_in_feeds: list[PostUsedInFeedModel],
-    ) -> list[PostToEnqueueModel]:
-        """Get the candidate pool posts used in the feeds for a given date."""
-        uris_of_posts_used_in_feeds: set[str] = {
-            post.uri for post in posts_used_in_feeds
-        }
-        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = [
-            post
-            for post in candidate_pool_posts
-            if post.uri in uris_of_posts_used_in_feeds
-        ]
-        return candidate_pool_posts_used_in_feeds
-
-    def _deduplicate_feed_posts(
-        self, posts: list[PostToEnqueueModel]
-    ) -> list[PostToEnqueueModel]:
-        """Deduplicate feed posts. A post can be used in feeds across multiple
-        dates, so we just want to grab one version of the post.
-        """
-        unique_uris: set[str] = set()
-        filtered_results: list[PostToEnqueueModel] = []
-        for post in posts:
-            if post.uri not in unique_uris:
-                unique_uris.add(post.uri)
-                filtered_results.append(post)
-        return filtered_results
 
     def get_previously_labeled_post_uris(
         self,

--- a/services/backfill/repositories/base.py
+++ b/services/backfill/repositories/base.py
@@ -2,7 +2,13 @@
 
 from abc import ABC, abstractmethod
 
-from services.backfill.models import PostToEnqueueModel
+from lib.constants import FEED_LOOKBACK_DAYS_DURING_STUDY, study_start_date
+from lib.datetime_utils import (
+    calculate_start_end_date_for_lookback,
+    get_partition_dates,
+)
+from services.backfill.exceptions import BackfillDataAdapterError
+from services.backfill.models import PostToEnqueueModel, PostUsedInFeedModel
 
 
 class BackfillDataAdapter(ABC):
@@ -23,7 +29,6 @@ class BackfillDataAdapter(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def load_feed_posts(
         self, start_date: str, end_date: str
     ) -> list[PostToEnqueueModel]:
@@ -34,9 +39,120 @@ class BackfillDataAdapter(ABC):
             end_date: End date in YYYY-MM-DD format (inclusive)
 
         Returns:
-            list[PostToEnqueueModel]: List of posts.
+            list[PostToEnqueueModel]: List of deduplicated feed posts.
+
+        Raises:
+            BackfillDataAdapterError: If loading feed posts fails.
+        """
+        try:
+            results: list[PostToEnqueueModel] = []
+            partition_dates: list[str] = get_partition_dates(
+                start_date=start_date, end_date=end_date
+            )
+            for partition_date in partition_dates:
+                results.extend(self._load_feed_posts_for_date(partition_date))
+            deduplicated_results: list[PostToEnqueueModel] = (
+                self._deduplicate_feed_posts(posts=results)
+            )
+            return deduplicated_results
+        except BackfillDataAdapterError:
+            raise
+        except Exception as e:
+            raise BackfillDataAdapterError(f"Failed to load feed posts: {e}") from e
+
+    @abstractmethod
+    def _load_posts_used_in_feeds_for_date(
+        self, partition_date: str
+    ) -> list[PostUsedInFeedModel]:
+        """Load the URIs of the posts used in the feeds for a given date.
+
+        Subclasses implement storage-specific logic.
+
+        Args:
+            partition_date: Partition date in YYYY-MM-DD format
+
+        Returns:
+            list[PostUsedInFeedModel]: List of posts used in feeds.
         """
         raise NotImplementedError
+
+    def _load_feed_posts_for_date(
+        self, partition_date: str
+    ) -> list[PostToEnqueueModel]:
+        """Load the posts used in the feeds for a given date."""
+        posts_used_in_feeds: list[PostUsedInFeedModel] = (
+            self._load_posts_used_in_feeds_for_date(partition_date)
+        )
+
+        lookback_start_date, lookback_end_date = calculate_start_end_date_for_lookback(
+            partition_date=partition_date,
+            num_days_lookback=FEED_LOOKBACK_DAYS_DURING_STUDY,
+            min_lookback_date=study_start_date,
+        )
+
+        candidate_pool_posts: list[PostToEnqueueModel] = (
+            self._load_candidate_pool_posts_for_date(
+                lookback_start_date=lookback_start_date,
+                lookback_end_date=lookback_end_date,
+            )
+        )
+
+        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = (
+            self._get_candidate_pool_posts_used_in_feeds_for_date(
+                candidate_pool_posts=candidate_pool_posts,
+                posts_used_in_feeds=posts_used_in_feeds,
+            )
+        )
+
+        return candidate_pool_posts_used_in_feeds
+
+    def _load_candidate_pool_posts_for_date(
+        self,
+        lookback_start_date: str,
+        lookback_end_date: str,
+    ) -> list[PostToEnqueueModel]:
+        """For feeds from a given date, load the posts that would've been
+        a part of the candidate pool for that date.
+
+        We need to reconstruct in this way because at the level of the feeds,
+        we only have the post URIs, so we need to artificially reconstruct
+        the candidate pool posts from the post URIs in order to have fully
+        hydrated posts.
+        """
+        return self.load_all_posts(
+            start_date=lookback_start_date,
+            end_date=lookback_end_date,
+        )
+
+    def _get_candidate_pool_posts_used_in_feeds_for_date(
+        self,
+        candidate_pool_posts: list[PostToEnqueueModel],
+        posts_used_in_feeds: list[PostUsedInFeedModel],
+    ) -> list[PostToEnqueueModel]:
+        """Get the candidate pool posts used in the feeds for a given date."""
+        uris_of_posts_used_in_feeds: set[str] = {
+            post.uri for post in posts_used_in_feeds
+        }
+        candidate_pool_posts_used_in_feeds: list[PostToEnqueueModel] = [
+            post
+            for post in candidate_pool_posts
+            if post.uri in uris_of_posts_used_in_feeds
+        ]
+        return candidate_pool_posts_used_in_feeds
+
+    def _deduplicate_feed_posts(
+        self, posts: list[PostToEnqueueModel]
+    ) -> list[PostToEnqueueModel]:
+        """Deduplicate feed posts. A post can be used in feeds across multiple
+        dates, so we just want to grab one version of the post.
+        """
+        unique_uris: set[str] = set()
+        filtered_results: list[PostToEnqueueModel] = []
+        for post in posts:
+            if post.uri not in unique_uris:
+                unique_uris.add(post.uri)
+                filtered_results.append(post)
+        return filtered_results
 
     @abstractmethod
     def get_previously_labeled_post_uris(

--- a/services/backfill/repositories/tests/test_adapters.py
+++ b/services/backfill/repositories/tests/test_adapters.py
@@ -117,7 +117,7 @@ class TestLocalStorageAdapter_load_feed_posts:
         partition_dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates, patch.object(
             local_storage_adapter, "_load_feed_posts_for_date"
         ) as mock_load_for_date:
@@ -166,7 +166,7 @@ class TestLocalStorageAdapter_load_feed_posts:
         end_date = "2024-01-31"
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates:
             mock_get_partition_dates.return_value = []
 
@@ -205,7 +205,7 @@ class TestLocalStorageAdapter_load_feed_posts_for_date:
         with patch.object(
             local_storage_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             local_storage_adapter, "_load_candidate_pool_posts_for_date"
         ) as mock_load_candidates, patch.object(
@@ -239,7 +239,7 @@ class TestLocalStorageAdapter_load_feed_posts_for_date:
         with patch.object(
             local_storage_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             local_storage_adapter, "_load_candidate_pool_posts_for_date"
         ), patch.object(
@@ -586,7 +586,7 @@ class TestS3Adapter_load_feed_posts:
         s3_adapter = S3Adapter(backend=mock_backend)
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates, patch.object(
             s3_adapter, "_load_feed_posts_for_date"
         ) as mock_load_for_date:
@@ -637,7 +637,7 @@ class TestS3Adapter_load_feed_posts:
         s3_adapter = S3Adapter(backend=mock_backend)
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates:
             mock_get_partition_dates.return_value = []
 
@@ -657,7 +657,7 @@ class TestS3Adapter_load_feed_posts:
         s3_adapter = S3Adapter(backend=mock_backend)
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates, patch.object(
             s3_adapter, "_load_feed_posts_for_date"
         ) as mock_load_for_date:
@@ -697,7 +697,7 @@ class TestS3Adapter_load_feed_posts:
         s3_adapter = S3Adapter(backend=mock_backend)
 
         with patch(
-            "services.backfill.repositories.adapters.get_partition_dates"
+            "services.backfill.repositories.base.get_partition_dates"
         ) as mock_get_partition_dates, patch.object(
             s3_adapter, "_load_feed_posts_for_date"
         ) as mock_load_for_date:
@@ -709,7 +709,7 @@ class TestS3Adapter_load_feed_posts:
                 s3_adapter.load_feed_posts(start_date=start_date, end_date=end_date)
 
             # Assert
-            assert "Failed to load feed posts from S3" in str(exc_info.value)
+            assert "Failed to load feed posts" in str(exc_info.value)
             assert "Backend error" in str(exc_info.value)
 
 
@@ -743,7 +743,7 @@ class TestS3Adapter_load_feed_posts_for_date:
         with patch.object(
             s3_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             s3_adapter, "_load_candidate_pool_posts_for_date"
         ) as mock_load_candidates, patch.object(
@@ -779,7 +779,7 @@ class TestS3Adapter_load_feed_posts_for_date:
         with patch.object(
             s3_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             s3_adapter, "_load_candidate_pool_posts_for_date"
         ), patch.object(
@@ -805,7 +805,7 @@ class TestS3Adapter_load_feed_posts_for_date:
         with patch.object(
             s3_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             s3_adapter, "_load_candidate_pool_posts_for_date"
         ) as mock_load_candidates, patch.object(
@@ -845,7 +845,7 @@ class TestS3Adapter_load_feed_posts_for_date:
         with patch.object(
             s3_adapter, "_load_posts_used_in_feeds_for_date"
         ) as mock_load_feeds, patch(
-            "services.backfill.repositories.adapters.calculate_start_end_date_for_lookback"
+            "services.backfill.repositories.base.calculate_start_end_date_for_lookback"
         ) as mock_calc_lookback, patch.object(
             s3_adapter, "_load_candidate_pool_posts_for_date"
         ) as mock_load_candidates, patch.object(


### PR DESCRIPTION
# PR Description

## Overview
Implement load_feed_posts for S3Adapter by mirroring the LocalStorageAdapter implementation pattern. The method loads feed posts from S3 by:

- Partitioning the date range
- For each partition date, loading posts used in feeds and reconstructing candidate pool posts
- Filtering candidate pool posts to only those used in feeds
- Deduplicating across partition dates

Also adds relevant unit tests 

## Implementation Details

### Files to Modify
1. services/backfill/repositories/adapters.py
Replace the stub implementation (lines 329-346) with a full implementation that mirrors LocalStorageAdapter.load_feed_posts:

- load_feed_posts: Main entry point that partitions dates and deduplicates results
- _load_feed_posts_for_date: Loads feed posts for a single partition date
- _load_posts_used_in_feeds_for_date: Loads post URIs used in feeds from S3 (uses POSTS_USED_IN_FEEDS_TABLE_NAME)
- _load_candidate_pool_posts_for_date: Delegates to load_all_posts (already implemented)
- _get_candidate_pool_posts_used_in_feeds_for_date: Filters candidate pool posts by URIs used in feeds (pure logic, can reuse from LocalStorageAdapter or duplicate)
- _deduplicate_feed_posts: Deduplicates posts by URI (pure logic, can reuse from LocalStorageAdapter or duplicate)

Key differences from LocalStorageAdapter:
- Use self.backend.query_dataset_as_df() instead of load_data_from_local_storage()
- Use S3ParquetDatasetRef(dataset=...) for dataset references
- Use partition_date parameter for single-date queries (not start_partition_date/end_partition_date)
- Error handling should wrap exceptions in BackfillDataAdapterError (similar to get_previously_labeled_post_uris)

Helper methods to add:

All helper methods should be private (prefixed with _)
- _load_posts_used_in_feeds_for_date should query fetch_posts_used_in_feeds dataset
- _get_candidate_pool_posts_used_in_feeds_for_date and _deduplicate_feed_posts are pure Python logic (no S3 calls)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored and hardened feed backfill: reliable aggregation across date partitions, proper ordering, deduplication, and clearer error handling.

* **Chores**
  * Expanded test coverage for backfill behavior, edge cases, deduplication, partition handling, and error wrapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->