### PR TITLE
Add `archive_ml_inference_intergroup` Glue table

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4112,6 +4112,71 @@ resource "aws_glue_catalog_table" "archive_ml_inference_ime" {
   }
 }
 
+# Archive table for ml_inference_intergroup
+resource "aws_glue_catalog_table" "archive_ml_inference_intergroup" {
+  name          = "archive_ml_inference_intergroup"
+  database_name = var.default_glue_database_name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL              = "TRUE"
+    "parquet.compression" = "SNAPPY"
+    "comment"             = "Archived Nature paper 2024 data - analysis use only, not production"
+  }
+
+  storage_descriptor {
+    location      = "s3://${var.s3_root_bucket_name}/bluesky_research/2024_nature_paper_study_data/ml_inference_intergroup/cache/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "ParquetHiveSerDe"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+      parameters = {
+        "serialization.format" = 1
+      }
+    }
+
+    columns {
+      name = "uri"
+      type = "string"
+    }
+    columns {
+      name = "text"
+      type = "string"
+    }
+    columns {
+      name = "preprocessing_timestamp"
+      type = "string"
+    }
+    columns {
+      name = "was_successfully_labeled"
+      type = "boolean"
+    }
+    columns {
+      name = "reason"
+      type = "string"
+    }
+    columns {
+      name = "label"
+      type = "bigint"
+    }
+    columns {
+      name = "source"
+      type = "string"
+    }
+    columns {
+      name = "label_timestamp"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "partition_date"
+    type = "string"
+  }
+}
+
 # Archive table for ml_inference_perspective_api
 resource "aws_glue_catalog_table" "archive_ml_inference_perspective_api" {
   name          = "archive_ml_inference_perspective_api"


### PR DESCRIPTION
# PR Description

We added the ability to migrate local data to S3 as part of our backfill script (https://github.com/METResearchGroup/bluesky-research/pull/365) because we wanted to migrate our ml_inference_intergroup labels to S3. This PR now adds a Glue table for the dataset. This is in alignment with other PRs where we created Glue tables (e.g.,https://github.com/METResearchGroup/bluesky-research/pull/330, https://github.com/METResearchGroup/bluesky-research/pull/329).

<img width="1349" height="544" alt="Screenshot 2026-01-22 at 3 50 11 PM" src="https://github.com/user-attachments/assets/1d34aab2-232b-4394-ad66-028d5eb28d69" />

<img width="1344" height="582" alt="Screenshot 2026-01-22 at 3 50 31 PM" src="https://github.com/user-attachments/assets/152af4c5-82f3-47e1-a34f-7d89da690ccd" />

<img width="1343" height="736" alt="Screenshot 2026-01-22 at 3 51 45 PM" src="https://github.com/user-attachments/assets/bf0bba9a-958a-4b39-903e-46a8819ebfee" />

We haven't labeled all posts with our intergroup classifier yet, so we only have a small test batch in S3. However, having Athena as our compute engine will help us use SQL queries to inspect our dataset while we do our backfills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new archive data table for intergroup ML inference data, extending research infrastructure with consistent storage and organizational capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->