### PR TITLE
Fix incorrect queue deletion behavior on batch/minibatch processing

### DIFF
--- a/lib/db/queue.py
+++ b/lib/db/queue.py
@@ -508,7 +508,9 @@ class Queue:
             total_items_before_delete = self.get_queue_length()
             cursor = conn.execute(query, tuple(ids_list))
             deleted_count = cursor.rowcount
-            total_items_after_delete = self.get_queue_length()
+            # Avoid querying queue length again here: get_queue_length() opens a new connection
+            # and may not see the uncommitted delete from `conn`, which makes logs misleading.
+            total_items_after_delete = max(total_items_before_delete - deleted_count, 0)
             logger.info(f"Deleted {deleted_count} items from queue.")
             logger.info(
                 f"Total items before delete: {total_items_before_delete}\tTotal items after delete: {total_items_after_delete}"


### PR DESCRIPTION
# PR Description

During backfills, we noticed that the row corresponding to a given batch_id would be deleted from the input queue, even if that whole batch hasn't been processed yet:

```bash
(base) ➜  bluesky-research git:(start-intergroup-backfills) ✗ uv run python -m pipelines.backfill_records_coordination.app --run-integrations --integrations g  --max-records-per-run 1200
2026-01-22 16:22:43,423 INFO [logger.py]: No connection provided, creating a new in-memory connection.
2026-01-22 16:22:43,542 INFO [logger.py]: Not clearing any queues.
2026-01-22 16:22:43,542 INFO [logger.py]: Running integrations: ml_inference_intergroup
2026-01-22 16:22:43,543 INFO [logger.py]: Running integration 1 of 1: ml_inference_intergroup
2026-01-22 16:22:50,908 INFO [logger.py]: Loading existing SQLite DB for queue input_ml_inference_intergroup...
2026-01-22 16:22:50,917 INFO [logger.py]: Current queue size: 14 items
2026-01-22 16:22:50,971 INFO [logger.py]: Loaded 13678 posts to classify.
2026-01-22 16:22:50,971 INFO [logger.py]: Getting posts to classify for inference type intergroup.
2026-01-22 16:22:50,971 INFO [logger.py]: Latest inference timestamp: None
2026-01-22 16:22:50,982 INFO [logger.py]: After dropping duplicates, 13678 posts remain.
2026-01-22 16:22:50,995 INFO [logger.py]: After filtering, 13508 posts remain.
Execution time for get_posts_to_classify: 0 minutes, 1 seconds
Memory usage for get_posts_to_classify: 33.8125 MB
2026-01-22 16:22:52,180 INFO [logger.py]: Limited posts from 13508 to 987 (max_records_per_run=1200, included 1 complete batches)
2026-01-22 16:22:52,183 INFO [logger.py]: Classifying 987 posts with intergroup classifier...
Classifying batches:   0%|                                                                                  | 0/50 [00:00<?, ?batch/s]2026-01-22 16:22:53,238 INFO [logger.py]: [Completion percentage: 0%] Processing batch 0/50...
2026-01-22 16:22:59,869 INFO [logger.py]: Successfully labeled 20 posts.
2026-01-22 16:22:59,870 INFO [logger.py]: DB for queue input_ml_inference_intergroup already exists. Not overwriting, using existing DB...
2026-01-22 16:22:59,870 INFO [logger.py]: Loading existing SQLite DB for queue input_ml_inference_intergroup...
2026-01-22 16:22:59,871 INFO [logger.py]: Current queue size: 14 items
2026-01-22 16:22:59,871 INFO [logger.py]: DB for queue output_ml_inference_intergroup already exists. Not overwriting, using existing DB...
2026-01-22 16:22:59,871 INFO [logger.py]: Loading existing SQLite DB for queue output_ml_inference_intergroup...
2026-01-22 16:22:59,874 INFO [logger.py]: Current queue size: 102 items
2026-01-22 16:22:59,874 INFO [logger.py]: Adding 20 posts to the output queue.
2026-01-22 16:22:59,874 INFO [logger.py]: Writing 20 items as 1 minibatches to DB.
2026-01-22 16:22:59,875 INFO [logger.py]: Writing 1 minibatches to DB as 1 batches...
2026-01-22 16:22:59,875 INFO [logger.py]: Processing batch 1/1...
2026-01-22 16:22:59,876 INFO [logger.py]: Deleting 1 batch IDs from the input queue.
2026-01-22 16:22:59,878 INFO [logger.py]: Deleted 1 items from queue.
2026-01-22 16:22:59,878 INFO [logger.py]: Total items before delete: 14 Total items after delete: 14
Classifying batches:   2%|▉                                                | 1/50 [00:06<05:25,  6.64s/batch, successful=20, failed=0]2026-01-22 16:23:08,916 INFO [logger.py]: Successfully labeled 20 posts.
```

Our intended workflow is:
- For a given batch, process in smaller minibatches
- Write each minibatch to permanent storage as they're being processed. This allows us to weigh the balance between classifying at the batch level while making the job resistant to failures.
- Delete the entire batch at once, after all their posts have been processed.

However, in practice, what it currently ends up being is something like:
- We have a batch of 1000
- We process that in minibatches of 20
- On the first minibatch, we write to storage
- BUT, as soon as that's done, we delete the batch ID
- THEREFORE, for the remaning 980 posts in that batch, they're loaded in memory already BUT have already been deleted from the input queue.
- So, this means that if the job is stopped at some point halfway through, those posts don't get labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved batch processing with better completion tracking; batches now deleted after all processing completes.
  * Restructured data export pipeline to separate output queue writes from input queue deletions.
  * Enhanced logging for queue operations to track items before and after deletion.

* **Tests**
  * Expanded test coverage for new batch processing and export separation logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->