### PR TITLE
Create `AsyncLLMService`

### DIFF
--- a/ml_tooling/llm/async_llm_service.py
+++ b/ml_tooling/llm/async_llm_service.py
@@ -1,0 +1,204 @@
+"""Async LLM service for interacting with LLM providers via LiteLLM."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TypeVar
+
+import litellm
+from litellm import ModelResponse
+from pydantic import BaseModel
+
+from ml_tooling.llm.base_llm_service import BaseLLMService
+from ml_tooling.llm.config.model_registry import ModelConfigRegistry
+from ml_tooling.llm.exceptions import standardize_litellm_exception
+from ml_tooling.llm.providers.base import LLMProviderProtocol
+from ml_tooling.llm.retry import retry_llm_completion
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class AsyncLLMService(BaseLLMService):
+    """LLM service for making API requests via LiteLLM (asynchronous)."""
+
+    async def _chat_completion_async(
+        self,
+        messages: list[dict],
+        model: str,
+        provider: LLMProviderProtocol,
+        response_format: type[BaseModel] | None = None,
+        **kwargs,
+    ) -> ModelResponse:
+        """Create an async chat completion request using the specified provider."""
+        completion_kwargs, _ = self._prepare_completion_kwargs(
+            model=model,
+            provider=provider,
+            response_format=response_format,
+            **kwargs,
+        )
+        completion_kwargs["messages"] = messages
+        # Avoid global LiteLLM state; use the provider instance's key per request.
+        completion_kwargs["api_key"] = provider.api_key
+
+        try:
+            result = await litellm.acompletion(**completion_kwargs)  # type: ignore
+        except Exception as e:
+            raise standardize_litellm_exception(e) from e
+
+        return (
+            result
+            if isinstance(result, ModelResponse)
+            else ModelResponse(**result.__dict__)  # type: ignore
+        )
+
+    async def _batch_completion_async(
+        self,
+        messages_list: list[list[dict]],
+        model: str,
+        provider: LLMProviderProtocol,
+        response_format: type[BaseModel] | None = None,
+        max_concurrent: int | None = None,
+        **kwargs,
+    ) -> list[ModelResponse]:
+        """Create async batch completion requests via concurrent `acompletion` calls.
+
+        Notes:
+            - `asyncio.gather()` preserves result ordering.
+            - `max_concurrent=None` means unbounded concurrency.
+            - `max_concurrent<=0` is treated as unbounded concurrency.
+        """
+        if not messages_list:
+            return []
+
+        completion_kwargs, _ = self._prepare_completion_kwargs(
+            model=model,
+            provider=provider,
+            response_format=response_format,
+            **kwargs,
+        )
+        completion_kwargs.pop("messages", None)
+        completion_kwargs["api_key"] = provider.api_key
+
+        async def _one(messages: list[dict]) -> ModelResponse:
+            request_kwargs = completion_kwargs.copy()
+            request_kwargs["messages"] = messages
+            try:
+                result = await litellm.acompletion(**request_kwargs)  # type: ignore
+            except Exception as e:
+                raise standardize_litellm_exception(e) from e
+
+            return (
+                result
+                if isinstance(result, ModelResponse)
+                else ModelResponse(**result.__dict__)  # type: ignore
+            )
+
+        if max_concurrent is None or max_concurrent <= 0:
+            tasks = [_one(messages) for messages in messages_list]
+            return list(await asyncio.gather(*tasks))
+
+        semaphore = asyncio.Semaphore(max_concurrent)
+
+        async def _limited(messages: list[dict]) -> ModelResponse:
+            async with semaphore:
+                return await _one(messages)
+
+        tasks = [_limited(messages) for messages in messages_list]
+        return list(await asyncio.gather(*tasks))
+
+    @retry_llm_completion(max_retries=3, initial_delay=1.0, max_delay=60.0)
+    async def _complete_and_validate_structured_async(
+        self,
+        messages: list[dict],
+        model: str,
+        provider: LLMProviderProtocol,
+        response_format: type[T],
+        **kwargs,
+    ) -> T:
+        """Execute async chat completion and validate/parse the response."""
+        response = await self._chat_completion_async(
+            messages=messages,
+            model=model,
+            provider=provider,
+            response_format=response_format,
+            **kwargs,
+        )
+        return self.handle_completion_response(response, response_format)
+
+    @retry_llm_completion(max_retries=3, initial_delay=1.0, max_delay=60.0)
+    async def _complete_and_validate_structured_batch_async(
+        self,
+        messages_list: list[list[dict]],
+        model: str,
+        provider: LLMProviderProtocol,
+        response_format: type[T],
+        max_concurrent: int | None = None,
+        **kwargs,
+    ) -> list[T]:
+        """Execute async batch completion and validate/parse all responses."""
+        responses = await self._batch_completion_async(
+            messages_list=messages_list,
+            model=model,
+            provider=provider,
+            response_format=response_format,
+            max_concurrent=max_concurrent,
+            **kwargs,
+        )
+        return self.handle_batch_completion_responses(responses, response_format)
+
+    async def structured_completion_async(
+        self,
+        messages: list[dict],
+        response_model: type[T],
+        model: str | None = None,
+        **kwargs,
+    ) -> T:
+        """Create an async chat completion request and return a Pydantic model."""
+        if model is None:
+            model = ModelConfigRegistry.get_default_model()
+        provider = self._get_provider_for_model(model)
+        return await self._complete_and_validate_structured_async(
+            messages=messages,
+            model=model,
+            provider=provider,
+            response_format=response_model,
+            **kwargs,
+        )
+
+    async def structured_batch_completion_async(
+        self,
+        prompts: list[str],
+        response_model: type[T],
+        model: str | None = None,
+        role: str = "user",
+        max_concurrent: int | None = None,
+        **kwargs,
+    ) -> list[T]:
+        """Create async batch completion requests and return Pydantic models."""
+        if model is None:
+            model = ModelConfigRegistry.get_default_model()
+        provider = self._get_provider_for_model(model)
+        messages_list = [[{"role": role, "content": prompt}] for prompt in prompts]
+        return await self._complete_and_validate_structured_batch_async(
+            messages_list=messages_list,
+            model=model,
+            provider=provider,
+            response_format=response_model,
+            max_concurrent=max_concurrent,
+            **kwargs,
+        )
+
+
+_async_llm_service_instance: AsyncLLMService | None = None
+_async_llm_service_lock = threading.Lock()
+
+
+def get_async_llm_service() -> AsyncLLMService:
+    """Dependency provider for async LLM service."""
+    global _async_llm_service_instance
+    if _async_llm_service_instance is None:
+        with _async_llm_service_lock:
+            if _async_llm_service_instance is None:
+                _async_llm_service_instance = AsyncLLMService()
+    return _async_llm_service_instance

--- a/ml_tooling/llm/base_llm_service.py
+++ b/ml_tooling/llm/base_llm_service.py
@@ -1,0 +1,135 @@
+"""Shared base for sync and async LLM services."""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from litellm import ModelResponse
+from pydantic import BaseModel
+
+from ml_tooling.llm.config.model_registry import ModelConfigRegistry
+from ml_tooling.llm.providers.base import LLMProviderProtocol
+from ml_tooling.llm.providers.registry import LLMProviderRegistry
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class BaseLLMService:
+    """Shared base for sync and async LLM services.
+
+    This class contains only synchronous helper methods that are shared by both
+    `LLMService` (sync) and `AsyncLLMService` (async) to avoid duplication.
+    """
+
+    def __init__(self, verbose: bool = False):
+        """Initialize the service.
+
+        Args:
+            verbose: If False (default), suppresses LiteLLM info and debug logs.
+                    If True, does not suppress LiteLLM logs (uses LiteLLM defaults).
+
+        Note: Providers are initialized lazily when first used to avoid
+        requiring API keys for all providers when only one is needed.
+        """
+        if not verbose:
+            self._suppress_litellm_logging()
+
+    def _suppress_litellm_logging(self) -> None:
+        """Configure logging to suppress LiteLLM info and debug logs.
+
+        See https://github.com/BerriAI/litellm/issues/6813
+        """
+        import logging
+
+        logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+
+    def _get_provider_for_model(self, model: str) -> LLMProviderProtocol:
+        """Get the provider instance for a given model.
+
+        Args:
+            model: Model identifier (e.g., 'gpt-4o-mini', 'groq/llama3-8b-8192')
+
+        Returns:
+            Provider instance that supports the given model
+
+        Raises:
+            ValueError: If no provider supports the given model
+        """
+        provider = LLMProviderRegistry.get_provider(model)
+        # Lazy initialization: only initialize the provider when it's actually used
+        if not getattr(provider, "_initialized", False):
+            provider.initialize()
+        return provider
+
+    def _prepare_completion_kwargs(
+        self,
+        model: str,
+        provider: LLMProviderProtocol,
+        response_format: type[BaseModel] | None = None,
+        **kwargs,
+    ) -> tuple[dict, dict[str, Any] | None]:
+        """Extract shared logic for preparing completion kwargs.
+
+        Used by both single and batch completion methods to avoid duplication.
+        Handles model config resolution, response format formatting, and kwargs
+        preparation via provider.
+        """
+        # Get model configuration from registry
+        try:
+            model_config_obj = ModelConfigRegistry.get_model_config(model)
+            # Convert ModelConfig to dict format expected by providers
+            model_config_dict = {
+                "kwargs": model_config_obj.get_all_llm_inference_kwargs()
+            }
+        except (ValueError, FileNotFoundError):
+            # Model not in config - use empty config dict
+            model_config_dict = {"kwargs": {}}
+
+        # Format structured output if needed (delegates to provider)
+        response_format_dict = None
+        if response_format is not None:
+            response_format_dict = provider.format_structured_output(
+                response_format, model_config_dict
+            )
+
+        # Prepare completion kwargs using provider-specific logic
+        # Note: messages is passed as placeholder empty list here, will be set by caller
+        completion_kwargs = provider.prepare_completion_kwargs(
+            model=model,
+            messages=[],  # Placeholder, will be set by caller
+            response_format=response_format_dict,
+            model_config=model_config_dict,
+            **kwargs,  # User kwargs override config kwargs
+        )
+
+        return completion_kwargs, response_format_dict
+
+    def handle_completion_response(
+        self,
+        response: ModelResponse,
+        response_model: type[T],
+    ) -> T:
+        """Handle a single completion response and parse into `response_model`."""
+        content: str | None = response.choices[0].message.content  # type: ignore
+        if content is None:
+            raise ValueError(
+                "Response content is None. Expected structured output from LLM."
+            )
+        return response_model.model_validate_json(content)
+
+    def handle_batch_completion_responses(
+        self,
+        responses: list[ModelResponse],
+        response_model: type[T],
+    ) -> list[T]:
+        """Handle batch completion responses and parse each into `response_model`."""
+        contents = []
+        for response in responses:
+            content: str | None = response.choices[0].message.content  # type: ignore
+            if content is None:
+                raise ValueError(
+                    "Response content is None. Expected structured output from LLM."
+                )
+            contents.append(content)
+
+        return [response_model.model_validate_json(content) for content in contents]

--- a/ml_tooling/llm/experiments/2026-01-23/README.md
+++ b/ml_tooling/llm/experiments/2026-01-23/README.md
@@ -1,0 +1,1 @@
+# Testing between async and sync inference

--- a/ml_tooling/llm/experiments/2026-01-23/experiment_sync_async.py
+++ b/ml_tooling/llm/experiments/2026-01-23/experiment_sync_async.py
@@ -1,0 +1,280 @@
+"""Compare sync vs async LLM inference for intergroup classification.
+
+This script:
+- Loads the intergroup eval dataset CSV used in the 2026-01-10 experiments
+- Generates prompts using the production intergroup prompt template
+- Runs inference with:
+  - `ml_tooling.llm.llm_service.LLMService` (sync)
+  - `ml_tooling.llm.async_llm_service.AsyncLLMService` (async)
+- Computes accuracy vs `gold_label` and measures runtime for both
+
+Example:
+  python ml_tooling/llm/experiments/2026-01-23/experiment_sync_async.py --max-samples 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, TypeVar
+
+import pandas as pd
+
+from lib.load_env_vars import EnvVarsContainer
+from ml_tooling.llm.async_llm_service import AsyncLLMService
+from ml_tooling.llm.llm_service import LLMService
+from ml_tooling.llm.prompt_utils import generate_batch_prompts
+from services.ml_inference.intergroup.constants import DEFAULT_BATCH_SIZE, DEFAULT_LLM_MODEL_NAME
+from services.ml_inference.intergroup.models import LabelChoiceModel
+from services.ml_inference.intergroup.prompts import INTERGROUP_PROMPT
+from services.ml_inference.models import PostToLabelModel
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    name: str
+    model: str
+    total: int
+    correct: int
+    failed: int
+    duration_s: float
+
+    @property
+    def accuracy(self) -> float:
+        return 0.0 if self.total == 0 else self.correct / self.total
+
+    @property
+    def throughput_rps(self) -> float:
+        return 0.0 if self.duration_s <= 0 else self.total / self.duration_s
+
+
+def _default_dataset_path() -> Path:
+    # experiment_sync_async.py -> 2026-01-23 -> experiments -> llm -> ml_tooling -> repo_root
+    repo_root = Path(__file__).resolve().parents[4]
+    return (
+        repo_root
+        / "services"
+        / "ml_inference"
+        / "intergroup"
+        / "experiments"
+        / "2026-01-10"
+        / "intergroup_eval_dataset.csv"
+    )
+
+
+TItem = TypeVar("TItem")
+
+
+def _iter_batches(items: list[TItem], batch_size: int) -> Iterable[list[TItem]]:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be > 0, got {batch_size}")
+    for i in range(0, len(items), batch_size):
+        yield items[i : i + batch_size]
+
+
+def _load_eval_dataset(csv_path: Path, max_samples: int | None = None) -> tuple[list[str], list[int]]:
+    df = pd.read_csv(csv_path)
+
+    if "text" not in df.columns:
+        raise ValueError(f"Expected CSV to contain column 'text'. Found: {list(df.columns)}")
+    if "gold_label" not in df.columns:
+        raise ValueError(
+            f"Expected CSV to contain column 'gold_label'. Found: {list(df.columns)}"
+        )
+
+    if max_samples is not None:
+        df = df.head(max_samples)
+
+    texts = [str(x) for x in df["text"].tolist()]
+    gold = [int(x) for x in df["gold_label"].tolist()]
+    return texts, gold
+
+
+def _make_posts(texts: list[str]) -> list[PostToLabelModel]:
+    # This dataset is for evaluation only; it doesn't carry the full queue metadata.
+    # Populate required fields with deterministic placeholders.
+    posts: list[PostToLabelModel] = []
+    for i, text in enumerate(texts):
+        posts.append(
+            PostToLabelModel(
+                uri=f"eval://intergroup/{i}",
+                text=text,
+                preprocessing_timestamp="eval",
+                batch_id=i,
+                batch_metadata="{}",
+            )
+        )
+    return posts
+
+
+def _make_prompts(posts: list[PostToLabelModel]) -> list[str]:
+    return generate_batch_prompts(
+        batch=posts,
+        prompt_template=INTERGROUP_PROMPT,
+        template_variable_to_model_field_mapping={"input": "text"},
+    )
+
+
+def _score_predictions(pred: list[int], gold: list[int]) -> tuple[int, int]:
+    if len(pred) != len(gold):
+        raise ValueError(f"Length mismatch: pred={len(pred)} gold={len(gold)}")
+    correct = sum(int(p == g) for p, g in zip(pred, gold))
+    failed = sum(int(p not in (0, 1)) for p in pred)
+    return correct, failed
+
+
+def run_sync(
+    *,
+    prompts: list[str],
+    gold: list[int],
+    model: str,
+    batch_size: int,
+) -> ExperimentResult:
+    service = LLMService()
+    predictions: list[int] = []
+
+    start = time.perf_counter()
+    for prompt_batch in _iter_batches(prompts, batch_size=batch_size):
+        responses: list[LabelChoiceModel] = service.structured_batch_completion(
+            prompts=prompt_batch,
+            response_model=LabelChoiceModel,
+            model=model,
+            role="user",
+        )
+        predictions.extend([r.label for r in responses])
+    duration_s = time.perf_counter() - start
+
+    correct, failed = _score_predictions(predictions, gold)
+    return ExperimentResult(
+        name="sync",
+        model=model,
+        total=len(gold),
+        correct=correct,
+        failed=failed,
+        duration_s=duration_s,
+    )
+
+
+async def run_async(
+    *,
+    prompts: list[str],
+    gold: list[int],
+    model: str,
+    batch_size: int,
+    max_concurrent: int,
+) -> ExperimentResult:
+    service = AsyncLLMService()
+    predictions: list[int] = []
+
+    start = time.perf_counter()
+    for prompt_batch in _iter_batches(prompts, batch_size=batch_size):
+        responses: list[LabelChoiceModel] = await service.structured_batch_completion_async(
+            prompts=prompt_batch,
+            response_model=LabelChoiceModel,
+            model=model,
+            role="user",
+            max_concurrent=max_concurrent,
+        )
+        predictions.extend([r.label for r in responses])
+    duration_s = time.perf_counter() - start
+
+    correct, failed = _score_predictions(predictions, gold)
+    return ExperimentResult(
+        name="async",
+        model=model,
+        total=len(gold),
+        correct=correct,
+        failed=failed,
+        duration_s=duration_s,
+    )
+
+
+def _print_result(r: ExperimentResult) -> None:
+    print("")
+    print(f"== {r.name} ==")
+    print(f"model: {r.model}")
+    print(f"total: {r.total}")
+    print(f"correct: {r.correct}")
+    print(f"failed_parse_or_other: {r.failed}")
+    print(f"accuracy: {r.accuracy:.4f}")
+    print(f"runtime_s: {r.duration_s:.2f}")
+    print(f"throughput_rps: {r.throughput_rps:.2f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare sync vs async LLM inference on intergroup eval dataset.")
+    parser.add_argument(
+        "--csv-path",
+        type=Path,
+        default=_default_dataset_path(),
+        help="Path to intergroup_eval_dataset.csv",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="If set, evaluate only the first N rows.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_LLM_MODEL_NAME,
+        help="LLM model name to use.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Number of prompts per batch.",
+    )
+    parser.add_argument(
+        "--async-max-concurrent",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Max concurrent requests inside each async batch.",
+    )
+    args = parser.parse_args()
+
+    # Ensure env vars are loaded and OpenAI key is available for LiteLLM.
+    openai_api_key = EnvVarsContainer.get_env_var("OPENAI_API_KEY", required=True)
+    os.environ["OPENAI_API_KEY"] = openai_api_key
+
+    csv_path: Path = args.csv_path
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV not found at: {csv_path}")
+
+    texts, gold = _load_eval_dataset(csv_path, max_samples=args.max_samples)
+    posts = _make_posts(texts)
+    prompts = _make_prompts(posts)
+
+    if len(prompts) != len(gold):
+        raise ValueError(f"Internal error: prompts={len(prompts)} gold={len(gold)}")
+
+    sync_result = run_sync(
+        prompts=prompts,
+        gold=gold,
+        model=args.model,
+        batch_size=args.batch_size,
+    )
+    async_result = asyncio.run(
+        run_async(
+            prompts=prompts,
+            gold=gold,
+            model=args.model,
+            batch_size=args.batch_size,
+            max_concurrent=args.async_max_concurrent,
+        )
+    )
+
+    print(f"dataset: {csv_path}")
+    print(f"prompt_template: services/ml_inference/intergroup/prompts.py::INTERGROUP_PROMPT")
+    _print_result(sync_result)
+    _print_result(async_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml_tooling/llm/llm_service.py
+++ b/ml_tooling/llm/llm_service.py
@@ -1,118 +1,23 @@
 """Service for interacting with LLM providers via LiteLLM."""
 
 import threading
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import litellm
 from litellm import ModelResponse, batch_completion
 from pydantic import BaseModel
 
+from ml_tooling.llm.base_llm_service import BaseLLMService
 from ml_tooling.llm.config.model_registry import ModelConfigRegistry
-from ml_tooling.llm.exceptions import (
-    standardize_litellm_exception,
-)
+from ml_tooling.llm.exceptions import standardize_litellm_exception
 from ml_tooling.llm.providers.base import LLMProviderProtocol
-from ml_tooling.llm.providers.registry import LLMProviderRegistry
 from ml_tooling.llm.retry import retry_llm_completion
 
 T = TypeVar("T", bound=BaseModel)
 
 
-class LLMService:
-    """LLM service for making API requests via LiteLLM."""
-
-    def __init__(self, verbose: bool = False):
-        """Initialize the LLM service.
-
-        Args:
-            verbose: If False (default), suppresses LiteLLM info and debug logs.
-                    If True, does not suppress LiteLLM logs (uses LiteLLM defaults).
-
-        Note: Providers are initialized lazily when first used to avoid
-        requiring API keys for all providers when only one is needed.
-        """
-        if not verbose:
-            self._suppress_litellm_logging()
-
-    def _suppress_litellm_logging(self) -> None:
-        """Configure logging to suppress LiteLLM info and debug logs.
-
-        See https://github.com/BerriAI/litellm/issues/6813
-        """
-        import logging
-
-        logging.getLogger("LiteLLM").setLevel(logging.WARNING)
-
-    def _get_provider_for_model(self, model: str) -> LLMProviderProtocol:
-        """Get the provider instance for a given model.
-
-        Args:
-            model: Model identifier (e.g., 'gpt-4o-mini', 'groq/llama3-8b-8192')
-
-        Returns:
-            Provider instance that supports the given model
-
-        Raises:
-            ValueError: If no provider supports the given model
-        """
-        provider = LLMProviderRegistry.get_provider(model)
-        # Lazy initialization: only initialize the provider when it's actually used
-        if not getattr(provider, "_initialized", False):
-            provider.initialize()
-        return provider
-
-    def _prepare_completion_kwargs(
-        self,
-        model: str,
-        provider: LLMProviderProtocol,
-        response_format: type[BaseModel] | None = None,
-        **kwargs,
-    ) -> tuple[dict, dict[str, Any] | None]:
-        """Extract shared logic for preparing completion kwargs.
-
-        Used by both single and batch completion methods to avoid duplication.
-        Handles model config resolution, response format formatting, and kwargs
-        preparation via provider.
-
-        Args:
-            model: Model identifier to use
-            provider: Provider instance for this model
-            response_format: Pydantic model class for structured outputs
-            **kwargs: Additional parameters to pass to the API (temperature, max_tokens, etc.)
-                These override any default kwargs from the model configuration.
-
-        Returns:
-            Tuple of (completion_kwargs dict, response_format_dict or None)
-        """
-        # Get model configuration from registry
-        try:
-            model_config_obj = ModelConfigRegistry.get_model_config(model)
-            # Convert ModelConfig to dict format expected by providers
-            model_config_dict = {
-                "kwargs": model_config_obj.get_all_llm_inference_kwargs()
-            }
-        except (ValueError, FileNotFoundError):
-            # Model not in config - use empty config dict
-            model_config_dict = {"kwargs": {}}
-
-        # Format structured output if needed (delegates to provider)
-        response_format_dict = None
-        if response_format is not None:
-            response_format_dict = provider.format_structured_output(
-                response_format, model_config_dict
-            )
-
-        # Prepare completion kwargs using provider-specific logic
-        # Note: messages is passed as placeholder empty list here, will be set by caller
-        completion_kwargs = provider.prepare_completion_kwargs(
-            model=model,
-            messages=[],  # Placeholder, will be set by caller
-            response_format=response_format_dict,
-            model_config=model_config_dict,
-            **kwargs,  # User kwargs override config kwargs
-        )
-
-        return completion_kwargs, response_format_dict
+class LLMService(BaseLLMService):
+    """LLM service for making API requests via LiteLLM (synchronous)."""
 
     def _chat_completion(
         self,
@@ -369,50 +274,6 @@ class LLMService:
             response_format=response_model,
             **kwargs,
         )
-
-    def handle_completion_response(
-        self,
-        response: ModelResponse,
-        response_model: type[T],
-    ) -> T:
-        """Handles the completion response."""
-        content: str | None = response.choices[0].message.content  # type: ignore
-        if content is None:
-            raise ValueError(
-                "Response content is None. Expected structured output from LLM."
-            )
-        return response_model.model_validate_json(content)
-
-    def handle_batch_completion_responses(
-        self,
-        responses: list[ModelResponse],
-        response_model: type[T],
-    ) -> list[T]:
-        """Handles batch completion responses.
-
-        Works the same as handle_completion_response but takes a list of responses.
-
-        Args:
-            responses: List of ModelResponse objects from batch completion
-            response_model: Pydantic model class to parse responses into
-
-        Returns:
-            List of Pydantic model instances parsed from responses
-
-        Raises:
-            ValueError: If any response content is None
-            ValidationError: If any response cannot be parsed into the Pydantic model
-        """
-        contents = []
-        for response in responses:
-            content: str | None = response.choices[0].message.content  # type: ignore
-            if content is None:
-                raise ValueError(
-                    "Response content is None. Expected structured output from LLM."
-                )
-            contents.append(content)
-
-        return [response_model.model_validate_json(content) for content in contents]
 
     def structured_batch_completion(
         self,

--- a/ml_tooling/llm/tests/test_async_llm_service.py
+++ b/ml_tooling/llm/tests/test_async_llm_service.py
@@ -1,0 +1,342 @@
+"""Unit tests for AsyncLLMService."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel, Field
+
+from ml_tooling.llm.async_llm_service import AsyncLLMService
+from ml_tooling.llm.exceptions import LLMAuthError, LLMTransientError
+from ml_tooling.llm.providers.base import LLMProviderProtocol
+
+
+class SamplePydanticModel(BaseModel):
+    value: str = Field(description="A test value")
+    number: int = Field(description="A test number")
+
+
+class _DummyProvider(LLMProviderProtocol):
+    """Minimal provider stub to satisfy AsyncLLMService internals in unit tests."""
+
+    _initialized = True
+    _api_key = "dummy-test-key"
+
+    @property
+    def provider_name(self) -> str:
+        return "dummy"
+
+    @property
+    def supported_models(self) -> list[str]:
+        return ["dummy-model"]
+
+    @property
+    def api_key(self) -> str:
+        return self._api_key
+
+    def initialize(self, api_key=None) -> None:  # noqa: ANN001
+        return None
+
+    def supports_model(self, model_name: str) -> bool:  # noqa: ARG002
+        return True
+
+    def format_structured_output(self, response_model, model_config):  # noqa: ANN001,ARG002
+        return {"type": "json_schema", "json_schema": {"schema": {}}}
+
+    def prepare_completion_kwargs(
+        self, model: str, messages: list[dict], response_format, model_config, **kwargs  # noqa: ANN001,ARG002
+    ) -> dict:
+        return {"model": model, "messages": messages, **kwargs}
+
+
+class TestAsyncLLMService__chat_completion_async:
+    """Tests for AsyncLLMService._chat_completion_async."""
+
+    @pytest.mark.asyncio
+    @patch("ml_tooling.llm.async_llm_service.litellm.acompletion", new_callable=AsyncMock)
+    async def test_reraises_standardized_exception_on_litellm_error(
+        self, mock_litellm_acompletion
+    ):
+        """_chat_completion_async should standardize and re-raise LiteLLM exceptions."""
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+        messages = [{"role": "user", "content": "test prompt"}]
+        mock_litellm_acompletion.side_effect = Exception("API error")
+
+        with patch.object(service, "_prepare_completion_kwargs", return_value=({}, None)):
+            with pytest.raises(Exception, match="API error"):
+                await service._chat_completion_async(
+                    messages=messages, model="gpt-4o-mini", provider=provider
+                )
+
+    @pytest.mark.asyncio
+    @patch("ml_tooling.llm.async_llm_service.litellm.acompletion", new_callable=AsyncMock)
+    async def test_returns_model_response(self, mock_litellm_acompletion):
+        """_chat_completion_async should return a ModelResponse from litellm.acompletion."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+        messages = [{"role": "user", "content": "test prompt"}]
+
+        mock_response = ModelResponse(
+            id="test-id",
+            choices=[Choices(message=Message(role="assistant", content="test response"))],
+        )
+        mock_litellm_acompletion.return_value = mock_response
+
+        with patch.object(service, "_prepare_completion_kwargs", return_value=({}, None)):
+            result = await service._chat_completion_async(
+                messages=messages, model="gpt-4o-mini", provider=provider
+            )
+
+        assert isinstance(result, ModelResponse)
+        assert result.id == "test-id"
+        mock_litellm_acompletion.assert_awaited_once()
+
+
+class TestAsyncLLMService__batch_completion_async:
+    """Tests for AsyncLLMService._batch_completion_async."""
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_list(self):
+        """_batch_completion_async should return an empty list for empty input."""
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+
+        result = await service._batch_completion_async(
+            messages_list=[], model="gpt-4o-mini", provider=provider
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    @patch("ml_tooling.llm.async_llm_service.litellm.acompletion", new_callable=AsyncMock)
+    async def test_preserves_order(self, mock_litellm_acompletion):
+        """_batch_completion_async should preserve input ordering in its outputs."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+        messages_list = [
+            [{"role": "user", "content": "p0"}],
+            [{"role": "user", "content": "p1"}],
+            [{"role": "user", "content": "p2"}],
+        ]
+
+        async def side_effect(*args, **kwargs):  # noqa: ANN001
+            content = kwargs["messages"][0]["content"]
+            # Invert completion timing so results would be scrambled without gather ordering.
+            await asyncio.sleep({"p0": 0.03, "p1": 0.02, "p2": 0.01}[content])
+            return ModelResponse(
+                id=f"id-{content}",
+                choices=[
+                    Choices(message=Message(role="assistant", content=f"resp-{content}"))
+                ],
+            )
+
+        mock_litellm_acompletion.side_effect = side_effect
+
+        with patch.object(service, "_prepare_completion_kwargs", return_value=({}, None)):
+            results = await service._batch_completion_async(
+                messages_list=messages_list, model="gpt-4o-mini", provider=provider
+            )
+
+        ids = [r.id for r in results]
+        assert ids == ["id-p0", "id-p1", "id-p2"]
+        assert mock_litellm_acompletion.await_count == 3
+
+    @pytest.mark.asyncio
+    @patch("ml_tooling.llm.async_llm_service.litellm.acompletion", new_callable=AsyncMock)
+    async def test_respects_max_concurrent(self, mock_litellm_acompletion):
+        """_batch_completion_async should not exceed max_concurrent in-flight requests."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+        messages_list = [[{"role": "user", "content": f"p{i}"}] for i in range(8)]
+
+        in_flight = 0
+        max_seen = 0
+        lock = asyncio.Lock()
+
+        async def side_effect(*args, **kwargs):  # noqa: ANN001
+            nonlocal in_flight, max_seen
+            async with lock:
+                in_flight += 1
+                max_seen = max(max_seen, in_flight)
+            await asyncio.sleep(0.02)
+            async with lock:
+                in_flight -= 1
+            content = kwargs["messages"][0]["content"]
+            return ModelResponse(
+                id=f"id-{content}",
+                choices=[Choices(message=Message(role="assistant", content=content))],
+            )
+
+        mock_litellm_acompletion.side_effect = side_effect
+
+        with patch.object(service, "_prepare_completion_kwargs", return_value=({}, None)):
+            _ = await service._batch_completion_async(
+                messages_list=messages_list,
+                model="gpt-4o-mini",
+                provider=provider,
+                max_concurrent=3,
+            )
+
+        assert max_seen <= 3
+
+
+class TestAsyncLLMService_structured_completion_async:
+    """Tests for AsyncLLMService.structured_completion_async."""
+
+    @pytest.mark.asyncio
+    async def test_parses_response_model(self):
+        """structured_completion_async should return a parsed Pydantic model."""
+        service = AsyncLLMService()
+        dummy_provider = _DummyProvider()
+        messages = [{"role": "user", "content": "test prompt"}]
+
+        parsed_model = SamplePydanticModel(value="test", number=42)
+
+        with patch.object(service, "_get_provider_for_model", return_value=dummy_provider):
+            with patch.object(
+                service, "_complete_and_validate_structured_async", return_value=parsed_model
+            ) as mock_complete:
+                result = await service.structured_completion_async(
+                    messages=messages,
+                    response_model=SamplePydanticModel,
+                    model="gpt-4o-mini",
+                    max_tokens=100,
+                    temperature=0.7,
+                )
+
+        assert isinstance(result, SamplePydanticModel)
+        assert result.value == "test"
+        assert result.number == 42
+        mock_complete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_kwargs_through(self):
+        """structured_completion_async should pass kwargs through to _complete_and_validate_structured_async."""
+        service = AsyncLLMService()
+        dummy_provider = _DummyProvider()
+        messages = [{"role": "user", "content": "test prompt"}]
+        parsed_model = SamplePydanticModel(value="test", number=42)
+
+        with patch.object(service, "_get_provider_for_model", return_value=dummy_provider):
+            with patch.object(
+                service, "_complete_and_validate_structured_async", return_value=parsed_model
+            ) as mock_complete:
+                _ = await service.structured_completion_async(
+                    messages=messages,
+                    response_model=SamplePydanticModel,
+                    model="gpt-4o-mini",
+                    max_tokens=200,
+                    temperature=0.5,
+                    top_p=0.9,
+                )
+
+        call_kwargs = mock_complete.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-4o-mini"
+        assert call_kwargs["response_format"] == SamplePydanticModel
+        assert call_kwargs["max_tokens"] == 200
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["top_p"] == 0.9
+
+
+class TestAsyncLLMService_structured_batch_completion_async:
+    """Tests for AsyncLLMService.structured_batch_completion_async."""
+
+    @pytest.mark.asyncio
+    async def test_passes_max_concurrent_through(self):
+        """structured_batch_completion_async should pass max_concurrent through to _complete_and_validate_structured_batch_async."""
+        service = AsyncLLMService()
+        dummy_provider = _DummyProvider()
+
+        parsed_models = [SamplePydanticModel(value="v", number=1)]
+
+        with patch.object(service, "_get_provider_for_model", return_value=dummy_provider):
+            with patch.object(
+                service,
+                "_complete_and_validate_structured_batch_async",
+                return_value=parsed_models,
+            ) as mock_complete:
+                _ = await service.structured_batch_completion_async(
+                    prompts=["p"],
+                    response_model=SamplePydanticModel,
+                    model="gpt-4o-mini",
+                    max_concurrent=7,
+                )
+
+        assert mock_complete.call_args.kwargs["max_concurrent"] == 7
+
+
+class TestRetryIntegration_async:
+    """Tests for retry behavior on async retry-decorated methods."""
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_then_succeeds(self):
+        """_complete_and_validate_structured_async should retry transient errors and eventually succeed."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+
+        expected = SamplePydanticModel(value="ok", number=1)
+
+        calls = 0
+
+        async def side_effect(*args, **kwargs):  # noqa: ANN001
+            nonlocal calls
+            calls += 1
+            if calls < 2:
+                raise LLMTransientError("transient")
+            # Return a LiteLLM-style response so parsing is exercised.
+            return ModelResponse(
+                id="test-id",
+                choices=[
+                    Choices(
+                        message=Message(
+                            role="assistant", content=expected.model_dump_json()
+                        )
+                    )
+                ],
+            )
+
+        with patch.object(service, "_chat_completion_async", side_effect=side_effect):
+            result = await service._complete_and_validate_structured_async(
+                messages=[{"role": "user", "content": "x"}],
+                model="gpt-4o-mini",
+                provider=provider,
+                response_format=SamplePydanticModel,
+            )
+
+        assert result == expected
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_auth_error(self):
+        """_complete_and_validate_structured_async should not retry auth errors."""
+        service = AsyncLLMService()
+        provider = _DummyProvider()
+
+        calls = 0
+
+        async def side_effect(*args, **kwargs):  # noqa: ANN001
+            nonlocal calls
+            calls += 1
+            raise LLMAuthError("nope")
+
+        with patch.object(service, "_chat_completion_async", side_effect=side_effect):
+            with pytest.raises(LLMAuthError, match="nope"):
+                await service._complete_and_validate_structured_async(
+                    messages=[{"role": "user", "content": "x"}],
+                    model="gpt-4o-mini",
+                    provider=provider,
+                    response_format=SamplePydanticModel,
+                )
+
+        assert calls == 1
+

--- a/ml_tooling/llm/tests/test_base_llm_service.py
+++ b/ml_tooling/llm/tests/test_base_llm_service.py
@@ -1,0 +1,245 @@
+"""Unit tests for BaseLLMService."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from ml_tooling.llm.base_llm_service import BaseLLMService
+from ml_tooling.llm.providers.base import LLMProviderProtocol
+
+
+class SamplePydanticModel(BaseModel):
+    value: str = Field(description="A test value")
+    number: int = Field(description="A test number")
+
+
+class TestBaseLLMService_handle_completion_response:
+    """Tests for BaseLLMService.handle_completion_response."""
+
+    def test_parses_valid_json(self):
+        """handle_completion_response should parse valid JSON into the response model."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        expected = SamplePydanticModel(value="v", number=1)
+        response = ModelResponse(
+            id="test-id",
+            choices=[
+                Choices(
+                    message=Message(role="assistant", content=expected.model_dump_json())
+                )
+            ],
+        )
+
+        result = service.handle_completion_response(response, SamplePydanticModel)
+
+        assert result == expected
+
+    def test_raises_value_error_when_content_is_none(self):
+        """handle_completion_response should raise ValueError when response content is None."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        response = ModelResponse(
+            id="test-id",
+            choices=[Choices(message=Message(role="assistant", content=None))],
+        )
+
+        with pytest.raises(ValueError, match="Response content is None"):
+            service.handle_completion_response(response, SamplePydanticModel)
+
+    def test_raises_validation_error_for_invalid_json(self):
+        """handle_completion_response should raise ValidationError for invalid JSON."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        response = ModelResponse(
+            id="test-id",
+            choices=[Choices(message=Message(role="assistant", content="{}"))],
+        )
+
+        with pytest.raises(ValidationError):
+            service.handle_completion_response(response, SamplePydanticModel)
+
+
+class TestBaseLLMService_handle_batch_completion_responses:
+    """Tests for BaseLLMService.handle_batch_completion_responses."""
+
+    def test_parses_all_responses_in_order(self):
+        """handle_batch_completion_responses should parse all responses into models in order."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        expected = [
+            SamplePydanticModel(value="a", number=1),
+            SamplePydanticModel(value="b", number=2),
+        ]
+        responses = [
+            ModelResponse(
+                id="id-a",
+                choices=[
+                    Choices(
+                        message=Message(
+                            role="assistant", content=expected[0].model_dump_json()
+                        )
+                    )
+                ],
+            ),
+            ModelResponse(
+                id="id-b",
+                choices=[
+                    Choices(
+                        message=Message(
+                            role="assistant", content=expected[1].model_dump_json()
+                        )
+                    )
+                ],
+            ),
+        ]
+
+        result = service.handle_batch_completion_responses(responses, SamplePydanticModel)
+
+        assert result == expected
+
+    def test_raises_value_error_when_any_content_is_none(self):
+        """handle_batch_completion_responses should raise ValueError if any response content is None."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        responses = [
+            ModelResponse(
+                id="id-a",
+                choices=[Choices(message=Message(role="assistant", content='{"value":"a","number":1}'))],
+            ),
+            ModelResponse(
+                id="id-b",
+                choices=[Choices(message=Message(role="assistant", content=None))],
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="Response content is None"):
+            service.handle_batch_completion_responses(responses, SamplePydanticModel)
+
+    def test_raises_validation_error_when_any_json_is_invalid(self):
+        """handle_batch_completion_responses should raise ValidationError if any response JSON is invalid."""
+        from litellm import Choices, Message, ModelResponse
+
+        service = BaseLLMService()
+        responses = [
+            ModelResponse(
+                id="id-a",
+                choices=[Choices(message=Message(role="assistant", content='{"value":"a","number":1}'))],
+            ),
+            ModelResponse(
+                id="id-b",
+                choices=[Choices(message=Message(role="assistant", content="{}"))],
+            ),
+        ]
+
+        with pytest.raises(ValidationError):
+            service.handle_batch_completion_responses(responses, SamplePydanticModel)
+
+
+class TestBaseLLMService__get_provider_for_model:
+    """Tests for BaseLLMService._get_provider_for_model."""
+
+    def test_initializes_provider_when_not_initialized(self):
+        """_get_provider_for_model should initialize provider if not already initialized."""
+        service = BaseLLMService()
+        provider = Mock(spec=LLMProviderProtocol)
+        setattr(provider, "_initialized", False)
+
+        with patch("ml_tooling.llm.base_llm_service.LLMProviderRegistry.get_provider", return_value=provider):
+            result = service._get_provider_for_model("some-model")
+
+        assert result is provider
+        provider.initialize.assert_called_once()
+
+    def test_does_not_initialize_provider_when_already_initialized(self):
+        """_get_provider_for_model should not initialize provider if already initialized."""
+        service = BaseLLMService()
+        provider = Mock(spec=LLMProviderProtocol)
+        setattr(provider, "_initialized", True)
+
+        with patch("ml_tooling.llm.base_llm_service.LLMProviderRegistry.get_provider", return_value=provider):
+            result = service._get_provider_for_model("some-model")
+
+        assert result is provider
+        provider.initialize.assert_not_called()
+
+
+class TestBaseLLMService__prepare_completion_kwargs:
+    """Tests for BaseLLMService._prepare_completion_kwargs."""
+
+    def test_uses_model_config_and_allows_overrides(self):
+        """_prepare_completion_kwargs should merge model config kwargs with user overrides."""
+        service = BaseLLMService()
+        provider = Mock(spec=LLMProviderProtocol)
+
+        model_config_obj = Mock()
+        model_config_obj.get_all_llm_inference_kwargs.return_value = {"temperature": 0.1}
+
+        provider.format_structured_output.return_value = {"type": "json_schema"}
+
+        captured = {}
+
+        def prepare_completion_kwargs(**kwargs):  # noqa: ANN001
+            captured.update(kwargs)
+            return {"ok": True}
+
+        provider.prepare_completion_kwargs.side_effect = prepare_completion_kwargs
+
+        with patch(
+            "ml_tooling.llm.base_llm_service.ModelConfigRegistry.get_model_config",
+            return_value=model_config_obj,
+        ):
+            completion_kwargs, response_format_dict = service._prepare_completion_kwargs(
+                model="m",
+                provider=provider,
+                response_format=SamplePydanticModel,
+                temperature=0.9,
+                max_tokens=123,
+            )
+
+        assert completion_kwargs == {"ok": True}
+        assert response_format_dict == {"type": "json_schema"}
+        assert captured["model"] == "m"
+        assert captured["messages"] == []
+        assert captured["response_format"] == {"type": "json_schema"}
+        assert captured["model_config"] == {"kwargs": {"temperature": 0.1}}
+        assert captured["temperature"] == 0.9
+        assert captured["max_tokens"] == 123
+
+    def test_falls_back_to_empty_model_config_when_missing(self):
+        """_prepare_completion_kwargs should fall back to empty model config if registry lookup fails."""
+        service = BaseLLMService()
+        provider = Mock(spec=LLMProviderProtocol)
+        provider.format_structured_output.return_value = None
+
+        captured = {}
+
+        def prepare_completion_kwargs(**kwargs):  # noqa: ANN001
+            captured.update(kwargs)
+            return {"ok": True}
+
+        provider.prepare_completion_kwargs.side_effect = prepare_completion_kwargs
+
+        with patch(
+            "ml_tooling.llm.base_llm_service.ModelConfigRegistry.get_model_config",
+            side_effect=ValueError("nope"),
+        ):
+            completion_kwargs, response_format_dict = service._prepare_completion_kwargs(
+                model="m",
+                provider=provider,
+                response_format=None,
+                temperature=0.5,
+            )
+
+        assert completion_kwargs == {"ok": True}
+        assert response_format_dict is None
+        assert captured["model_config"] == {"kwargs": {}}
+        assert captured["temperature"] == 0.5
+

--- a/ml_tooling/llm/tests/test_llm_service.py
+++ b/ml_tooling/llm/tests/test_llm_service.py
@@ -110,58 +110,6 @@ class TestLLMService:
         assert result.number == 42
         mock_complete.assert_called_once()
 
-    def test_structured_completion_raises_value_error_when_content_is_none(self):
-        """Verify structured_completion raises ValueError when response content is None."""
-        service = LLMService()
-        dummy_provider = _DummyProvider()
-        messages = [{"role": "user", "content": "test prompt"}]
-
-        with patch.object(service, "_get_provider_for_model", return_value=dummy_provider):
-            # Mock _complete_and_validate_structured to raise ValueError (simulating handle_completion_response)
-            with patch.object(
-                service,
-                "_complete_and_validate_structured",
-                side_effect=ValueError(
-                    "Response content is None. Expected structured output from LLM."
-                ),
-            ):
-                with pytest.raises(ValueError, match="Response content is None"):
-                    service.structured_completion(
-                        messages=messages,
-                        response_model=SamplePydanticModel,
-                        model="gpt-4o-mini",
-                    )
-
-    def test_structured_completion_raises_validation_error_for_invalid_json(self):
-        """Verify structured_completion raises ValidationError for invalid JSON response."""
-        from pydantic import ValidationError
-
-        service = LLMService()
-        dummy_provider = _DummyProvider()
-        messages = [{"role": "user", "content": "test prompt"}]
-
-        # Create a ValidationError by trying to parse invalid data
-        # This will definitely raise a ValidationError since required fields are missing
-        validation_error: ValidationError
-        try:
-            SamplePydanticModel.model_validate({})  # Empty dict will fail validation
-            # This should never happen, but satisfy type checker
-            raise AssertionError("Expected ValidationError was not raised")
-        except ValidationError as e:
-            validation_error = e
-
-        with patch.object(service, "_get_provider_for_model", return_value=dummy_provider):
-            # Mock _complete_and_validate_structured to raise ValidationError
-            with patch.object(
-                service, "_complete_and_validate_structured", side_effect=validation_error
-            ):
-                with pytest.raises(ValidationError):
-                    service.structured_completion(
-                        messages=messages,
-                        response_model=SamplePydanticModel,
-                        model="gpt-4o-mini",
-                    )
-
     def test_structured_completion_passes_kwargs_to_complete_and_validate(self):
         """Verify structured_completion passes kwargs through to _complete_and_validate_structured."""
         service = LLMService()


### PR DESCRIPTION
# PR Description

We've been doing experiments with trying to speed up inference (https://github.com/METResearchGroup/bluesky-research/pull/369). One other promising avenue of experimentation is to make inference async. Logically this would make sense, given that requests are network-bound and not compute-bound. In other work in the lab (https://trello.com/c/xYQ1HIuO/4-do-scale-testing-for-ai-inference, https://github.com/METResearchGroup/mind_technology_lab_experiments/pull/3/) we had quite promising results when using (unoptimized, naive) async with an ad-hoc semaphore count.

Based on how promising those results were, we're interested in creating an async version of our current LLM service and we want to see how that performs compared to our original version.

Here, we do the following:
1. Introduce a `BaseLLMService` with shared functionalities.
2. Refactor `LLMService` to inherit from `BaseLLMService` and expose the same synchronous endpoints as before.
3. Create a new `AsyncLLMService` to expose async versions of the same endpoints as `LLMService`

To verify no regression, we run the same unit tests already existing for `LLMService`. We also expand the unit test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous LLM service with structured single and batched completions, per-request key handling, and configurable concurrency.
  * Built-in retry and standardized error handling for async completions.

* **Refactor**
  * Core LLM service split to share a new base service for common parsing/preparation and to simplify internal flows.

* **Tests**
  * Comprehensive unit tests for async and base behaviors (ordering, concurrency, retries, parsing).

* **Experiments**
  * Added a sync vs. async benchmarking script and README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->