### PR TITLE
Fix Python CI: Vulture Click callback, pytest paths, complexipy hook

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -98,7 +98,6 @@ jobs:
           services/calculate_superposters/tests \
           services/preprocess_raw_data/tests \
           services/sync/stream/tests \
-          services/sync/jetstream/tests \
           transform/tests
 
     - name: Lint Dockerfiles with Hadolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
     rev: v3.0.0
     hooks:
       - id: complexipy
+        args: [--ignore-complexity]

--- a/pipelines/backfill_records_coordination/app.py
+++ b/pipelines/backfill_records_coordination/app.py
@@ -37,7 +37,7 @@ DEFAULT_INTEGRATION_KWARGS = {
 }
 
 
-def validate_date_format(ctx, param, value):
+def validate_date_format(_ctx, _param, value):
     """Validates date string format (YYYY-MM-DD)."""
     if value is None:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,6 @@ testpaths = [
     "services/consolidate_enrichment_integrations/tests",
     "services/calculate_superposters/tests",
     "services/sync/stream/tests",
-    "services/sync/jetstream/tests",
     "pipelines/backfill_records_coordination/tests",
     "pipelines/classify_records/perspective_api/tests",
     "pipelines/classify_records/ime/tests",


### PR DESCRIPTION
### Overview

Restore a green **Python CI** workflow on `main` by fixing the Vulture dead-code step, correcting pytest collection for the explicit test-path list, and aligning the local complexipy pre-commit hook with `[tool.complexipy]` in `pyproject.toml`.

### Problem / motivation

CI failed on **Vulture (dead code)** (exit code 3) with:

```
pipelines/backfill_records_coordination/app.py:40: unused variable 'ctx' (100% confidence)
```

After fixing Vulture, the same workflow failed at **Test with pytest** (exit code 5): pytest reported `2 workers [0 items]` because the workflow passed a non-existent directory `services/sync/jetstream/tests`, which breaks collection for the entire multi-path invocation.

Committing the Vulture fix also failed locally: **complexipy** pre-commit exited 1 even though `uv run complexipy` respects `ignore-complexity = true` in `pyproject.toml`.

### Solution

- Prefix unused Click callback parameters with underscores so Vulture treats them as intentionally unused while preserving the Click API.
- Pass `--ignore-complexity` to the complexipy pre-commit hook so it matches CI and `pyproject.toml`.
- Remove `services/sync/jetstream/tests` from the GitHub Actions pytest step and from `[tool.pytest.ini_options] testpaths` until that package exists in the tree.

### Happy Flow

1. Developer edits `pipelines/backfill_records_coordination/app.py` and runs `git commit` — pre-commit runs ruff, ruff-format, and complexipy without a false failure.
2. CI runs **Vulture** — no unused-parameter finding for the date validator callback.
3. CI runs **pytest** with the explicit directory list — tests are collected and executed normally.

### Data Flow

N/A (tooling and static configuration only.)

### Manual Verification

- `uv run vulture --config pyproject.toml` — exits 0.
- `uv run pytest --import-mode=importlib -n auto --dist loadfile` with the same directory list as `.github/workflows/python-ci.yml` (after removing the jetstream path) — collects a non-zero number of tests locally.
- GitHub Actions **Python CI** on branch `fix/ci-vulture-click-callback-unused-params` — all matrix jobs green ([run](https://github.com/METResearchGroup/bluesky-research/actions/runs/25887744311)).

### Changes

- `pipelines/backfill_records_coordination/app.py`: rename `ctx` / `param` to `_ctx` / `_param` in `validate_date_format`.
- `.pre-commit-config.yaml`: add `args: [--ignore-complexity]` to the complexipy hook.
- `.github/workflows/python-ci.yml`: drop `services/sync/jetstream/tests` from the pytest invocation.
- `pyproject.toml`: remove the same path from `testpaths`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow and pytest configuration to adjust test discovery paths.
  * Updated pre-commit hook configuration for code quality analysis.

* **Refactor**
  * Refined callback function parameter naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/bluesky-research/pull/393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->