### PR TITLE
[2026-05-14] Codex repo automation - bug fixes

### DIFF
--- a/lib/db/service_constants.py
+++ b/lib/db/service_constants.py
@@ -541,6 +541,46 @@ MAP_SERVICE_TO_METADATA = {
             "partition_date": "string",
         },
     },
+    "study_user_activity": {
+        "local_prefix": os.path.join(root_local_data_directory, "study_user_activity"),
+        "s3_prefix": os.path.join("study_user_activity", "create", "post"),
+        "glue_table_name": "study_user_activity",
+        "primary_key": "uri",
+        "timestamp_field": "synctimestamp",
+        "skip_deduping": False,
+        "pydantic_model": "",
+        "subpaths": {
+            "post": os.path.join(
+                root_local_data_directory, "study_user_activity", "create", "post"
+            ),
+        },
+        "dtypes_map": {
+            "uri": "string",
+            "cid": "string",
+            "indexed_at": "string",
+            "author_did": "string",
+            "author_handle": "string",
+            "author_avatar": "string",
+            "author_display_name": "string",
+            "created_at": "string",
+            "text": "string",
+            "embed": "string",
+            "entities": "string",
+            "facets": "string",
+            "labels": "string",
+            "langs": "string",
+            "reply_parent": "string",
+            "reply_root": "string",
+            "tags": "string",
+            "synctimestamp": "string",
+            "url": "string",
+            "source": "string",
+            "like_count": "Int64",
+            "reply_count": "Int64",
+            "repost_count": "Int64",
+            "partition_date": "string",
+        },
+    },
     # each row is a unique relationship, so no deduping required.
     "scraped_user_social_network": {
         "local_prefix": os.path.join(


### PR DESCRIPTION
## Overview
Codex automation fixed a regression from the recent refactor.

## Problem
`study_user_activity` metadata was removed, but recent loaders still reference it. That causes runtime `KeyError` failures in the affected paths.

## Solution
Restored the `study_user_activity` entry in `lib/db/service_constants.py` with the metadata required by the existing loaders.

## Changes
- Restored `study_user_activity` metadata in `lib/db/service_constants.py`
- Kept the change narrow to the missing service definition only
- Verified the file parses with `python -m py_compile`

## Manual Verification
- `python -m py_compile lib/db/service_constants.py`

Codex automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for study user activity data integration, enabling access to new activity tracking data sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/bluesky-research/pull/395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->